### PR TITLE
V1.2.1

### DIFF
--- a/DSP2803x_common/source/DSP2803x_DefaultIsr.c
+++ b/DSP2803x_common/source/DSP2803x_DefaultIsr.c
@@ -1,0 +1,1089 @@
+// TI File $Revision: /main/3 $
+// Checkin $Date: July 6, 2009   16:09:26 $
+//###########################################################################
+//
+// FILE:	DSP2803x_DefaultIsr.c
+//
+// TITLE:	DSP2803x Device Default Interrupt Service Routines.
+//
+// This file contains shell ISR routines for the 2803x PIE vector table.
+// Typically these shell ISR routines can be used to populate the entire PIE
+// vector table during device debug.  In this manner if an interrupt is taken
+// during firmware development, there will always be an ISR to catch it.
+//
+// As develpment progresses, these ISR rotuines can be eliminated and replaced
+// with the user's own ISR routines for each interrupt.  Since these shell ISRs
+// include infinite loops they will typically not be included as-is in the final
+// production firmware.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+// Connected to INT13 of CPU (use MINT13 mask):
+// ISR can be used by the user.
+interrupt void INT13_ISR(void)     // INT13 or CPU-Timer1
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void INT14_ISR(void)     // INT14 or CPU-Timer2
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void DATALOG_ISR(void)   // Datalogging interrupt
+{
+   // Insert ISR Code here
+
+   // Next two lines for debug only to halt the processor here
+   // Remove after inserting ISR Code
+   asm ("      ESTOP0");
+   for(;;);
+}
+
+interrupt void RTOSINT_ISR(void)   // RTOS interrupt
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void EMUINT_ISR(void)    // Emulation interrupt
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void NMI_ISR(void)       // Non-maskable interrupt
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void ILLEGAL_ISR(void)   // Illegal operation TRAP
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm("          ESTOP0");
+  for(;;);
+
+}
+
+interrupt void USER1_ISR(void)     // User Defined trap 1
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+interrupt void USER2_ISR(void)     // User Defined trap 2
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+interrupt void USER3_ISR(void)     // User Defined trap 3
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER4_ISR(void)     // User Defined trap 4
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER5_ISR(void)     // User Defined trap 5
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER6_ISR(void)     // User Defined trap 6
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER7_ISR(void)     // User Defined trap 7
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER8_ISR(void)     // User Defined trap 8
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER9_ISR(void)     // User Defined trap 9
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER10_ISR(void)    // User Defined trap 10
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER11_ISR(void)    // User Defined trap 11
+{
+  // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void USER12_ISR(void)     // User Defined trap 12
+{
+ // Insert ISR Code here
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// -----------------------------------------------------------
+// PIE Group 1 - MUXed into CPU INT1
+// -----------------------------------------------------------
+// INT1.1
+interrupt void ADCINT1_ISR(void)   // ADC  (Can also be ISR for INT10.1 when enabled)
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP1;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT1.2
+interrupt void ADCINT2_ISR(void)  // ADC  (Can also be ISR for INT10.2 when enabled)
+{
+
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP1;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+
+  asm("	  ESTOP0");
+  for(;;);
+
+}
+
+// INT1.3 - Reserved
+
+// INT1.4
+interrupt void  XINT1_ISR(void)
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP1;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT1.5
+interrupt void  XINT2_ISR(void)
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP1;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT1.6
+interrupt void  ADCINT9_ISR(void)     // ADC
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP1;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT1.7
+interrupt void  TINT0_ISR(void)      // CPU-Timer 0
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP1;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT1.8
+interrupt void  WAKEINT_ISR(void)    // WD, LOW Power
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP1;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// -----------------------------------------------------------
+// PIE Group 2 - MUXed into CPU INT2
+// -----------------------------------------------------------
+
+// INT2.1
+interrupt void EPWM1_TZINT_ISR(void)    // EPWM-1
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP2;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT2.2
+interrupt void EPWM2_TZINT_ISR(void)    // EPWM-2
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP2;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT2.3
+interrupt void EPWM3_TZINT_ISR(void)    // EPWM-3
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP2;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT2.4
+interrupt void EPWM4_TZINT_ISR(void)    // EPWM-4
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP2;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT2.5
+interrupt void EPWM5_TZINT_ISR(void)    // EPWM-5
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP2;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT2.6
+interrupt void EPWM6_TZINT_ISR(void)    // EPWM-6
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP2;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT2.7
+interrupt void EPWM7_TZINT_ISR(void)    // EPWM-7
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP2;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT2.8 - Reserved
+
+// -----------------------------------------------------------
+// PIE Group 3 - MUXed into CPU INT3
+// -----------------------------------------------------------
+
+// INT 3.1
+interrupt void EPWM1_INT_ISR(void)     // EPWM-1
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP3;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT3.2
+interrupt void EPWM2_INT_ISR(void)     // EPWM-2
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP3;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT3.3
+interrupt void EPWM3_INT_ISR(void)    // EPWM-3
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP3;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT3.4
+interrupt void EPWM4_INT_ISR(void)    // EPWM-4
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP3;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT3.5
+interrupt void EPWM5_INT_ISR(void)    // EPWM-5
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP3;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT3.5
+interrupt void EPWM6_INT_ISR(void)    // EPWM-6
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP3;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT3.5
+interrupt void EPWM7_INT_ISR(void)    // EPWM-7
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP3;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT3.8 - Reserved
+
+// -----------------------------------------------------------
+// PIE Group 4 - MUXed into CPU INT4
+// -----------------------------------------------------------
+
+// INT 4.1
+interrupt void ECAP1_INT_ISR(void)    // ECAP-1
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP4;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT4.2 - Reserved
+// INT4.3 - Reserved
+// INT4.4 - Reserved
+// INT4.5 - Reserved
+// INT4.6 - Reserved
+// INT4.7 - Reserved
+// INT4.8 - Reserved
+
+// -----------------------------------------------------------
+// PIE Group 5 - MUXed into CPU INT5
+// -----------------------------------------------------------
+
+// INT 5.1
+interrupt void EQEP1_INT_ISR(void)    // EQEP-1
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP5;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT5.2 - Reserved
+// INT5.3 - Reserved
+// INT5.4 - Reserved
+// INT5.5 - Reserved
+// INT5.6 - Reserved
+// INT5.7 - Reserved
+// INT5.8 - Reserved
+
+// -----------------------------------------------------------
+// PIE Group 6 - MUXed into CPU INT6
+// -----------------------------------------------------------
+
+// INT6.1
+interrupt void SPIRXINTA_ISR(void)    // SPI-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP6;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT6.2
+interrupt void SPITXINTA_ISR(void)     // SPI-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP6;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT6.3
+interrupt void SPIRXINTB_ISR(void)    // SPI-B
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP6;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT6.4
+interrupt void SPITXINTB_ISR(void)     // SPI-B
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP6;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT6.5 - Reserved
+// INT6.6 - Reserved
+// INT6.7 - Reserved
+// INT6.8 - Reserved
+
+// -----------------------------------------------------------
+// PIE Group 7 - MUXed into CPU INT7
+// -----------------------------------------------------------
+
+// -----------------------------------------------------------
+// PIE Group 8 - MUXed into CPU INT8
+// -----------------------------------------------------------
+
+// INT8.1
+interrupt void I2CINT1A_ISR(void)     // I2C-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP8;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT8.2
+interrupt void I2CINT2A_ISR(void)     // I2C-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP8;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT8.3 - Reserved
+// INT8.4 - Reserved
+// INT8.5 - Reserved
+// INT8.6 - Reserved
+// INT8.7 - Reserved
+// INT8.8 - Reserved
+
+// -----------------------------------------------------------
+// PIE Group 9 - MUXed into CPU INT9
+// -----------------------------------------------------------
+
+// INT9.1
+interrupt void SCIRXINTA_ISR(void)     // SCI-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP9;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT9.2
+interrupt void SCITXINTA_ISR(void)     // SCI-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP9;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT9.3
+interrupt void LIN0INTA_ISR(void)     // LIN-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP9;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT9.4
+interrupt void LIN1INTA_ISR(void)     // LIN-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP9;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT9.5
+interrupt void ECAN0INTA_ISR(void)  // eCAN-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP9;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT9.6
+interrupt void ECAN1INTA_ISR(void)  // eCAN-A
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP9;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT9.7 - Reserved
+// INT9.8 - Reserved
+
+// -----------------------------------------------------------
+// PIE Group 10 - MUXed into CPU INT10
+// -----------------------------------------------------------
+
+// INT10.1 - Reserved or ADCINT1_ISR
+// INT10.2 - Reserved or ADCINT2_ISR
+
+// INT10.3
+interrupt void ADCINT3_ISR(void)    // ADC
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP10;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT10.4
+interrupt void ADCINT4_ISR(void)    // ADC
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP10;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT10.5
+interrupt void ADCINT5_ISR(void)    // ADC
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP10;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT10.6
+interrupt void ADCINT6_ISR(void)    // ADC
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP10;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT10.7
+interrupt void ADCINT7_ISR(void)    // ADC
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP10;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT10.8
+interrupt void ADCINT8_ISR(void)    // ADC
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP10;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+
+// -----------------------------------------------------------
+// PIE Group 11 - MUXed into CPU INT11
+// -----------------------------------------------------------
+
+// INT11.1
+interrupt void CLA1_INT1_ISR(void)   // MCLA
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT11.2
+interrupt void CLA1_INT2_ISR(void)  // MCLA
+{
+
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+
+  asm("	  ESTOP0");
+  for(;;);
+
+}
+
+// INT11.3
+interrupt void CLA1_INT3_ISR(void)    // MCLA
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT11.4
+interrupt void CLA1_INT4_ISR(void)    // MCLA
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT11.5
+interrupt void CLA1_INT5_ISR(void)    // MCLA
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT11.6
+interrupt void CLA1_INT6_ISR(void)    // MCLA
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT11.7
+interrupt void CLA1_INT7_ISR(void)    // MCLA
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// INT11.8
+interrupt void CLA1_INT8_ISR(void)    // MCLA
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP11;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+// -----------------------------------------------------------
+// PIE Group 12 - MUXed into CPU INT12
+// -----------------------------------------------------------
+
+// INT12.1
+interrupt void XINT3_ISR(void)  // External interrupt 3
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP12;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+// INT12.2 - Reserved
+// INT12.3 - Reserved
+// INT12.4 - Reserved
+// INT12.5 - Reserved
+// INT12.6 - Reserved
+
+// INT12.7
+interrupt void LVF_ISR(void)  // CLA1 - overflow
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP12;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+// INT12.8
+interrupt void LUF_ISR(void)  // CLA1 - underflow
+{
+  // Insert ISR Code here
+
+  // To receive more interrupts from this PIE group, acknowledge this interrupt
+  // PieCtrlRegs.PIEACK.all = PIEACK_GROUP12;
+
+  // Next two lines for debug only to halt the processor here
+  // Remove after inserting ISR Code
+  asm ("      ESTOP0");
+  for(;;);
+
+}
+
+//---------------------------------------------------------------------------
+// Catch All Default ISRs:
+//
+
+interrupt void EMPTY_ISR(void)  // Empty ISR - only does a return.
+{
+
+}
+
+interrupt void PIE_RESERVED(void)  // Reserved space.  For test.
+{
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+interrupt void rsvd_ISR(void)      // For test
+{
+  asm ("      ESTOP0");
+  for(;;);
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================
+

--- a/DSP2803x_common/source/DSP2803x_DisInt.asm
+++ b/DSP2803x_common/source/DSP2803x_DisInt.asm
@@ -1,0 +1,60 @@
+;// TI File $Revision: /main/1 $
+;// Checkin $Date: December 5, 2008   18:00:53 $
+;//###########################################################################
+;//
+;// FILE:  DSP2803x_DisInt.asm	
+;//
+;// TITLE: Disable and Restore INTM and DBGM
+;// 
+;// Function Prototypes:
+;//
+;//      Uint16 DSP28x_DisableInt();
+;// and  void DSP28x_RestoreInt(Uint16 Stat0);
+;//
+;// Usage:
+;//
+;//      DSP28x_DisableInt() sets both the INTM and DBGM
+;//      bits to disable maskable interrupts.  Before doing
+;//      this, the current value of ST1 is stored on the stack
+;//      so that the values can be restored later.  The value
+;//      of ST1 before the masks are set is returned to the
+;//      user in AL.  This is then used to restore their state
+;//      via the DSP28x_RestoreInt(Uint16 ST1) function.
+;//
+;// Example
+;//
+;//   Uint16 StatusReg1    
+;//   StatusReg1 = DSP28x_DisableInt();
+;//
+;//   ... May also want to disable INTM here
+;// 
+;//   ... code here
+;//
+;//   DSP28x_RestoreInt(StatusReg1);
+;//
+;//   ... Restore INTM enable
+;//
+;//###########################################################################
+;// $TI Release: 2803x C/C++ Header Files V1.21 $
+;// $Release Date: December 1, 2009 $
+;//###########################################################################
+
+   .def _DSP28x_DisableInt
+   .def _DSP28x_RestoreInt
+
+_DSP28x_DisableInt:
+    PUSH  ST1
+    SETC  INTM,DBGM
+    MOV   AL, *--SP
+    LRETR
+
+_DSP28x_RestoreInt:
+    MOV   *SP++, AL
+    POP   ST1
+    LRETR
+
+;//===========================================================================
+;// End of file.
+;//===========================================================================
+
+   

--- a/DSP2803x_common/source/DSP2803x_ECan.c
+++ b/DSP2803x_common/source/DSP2803x_ECan.c
@@ -1,0 +1,202 @@
+// TI File $Revision: /main/3 $
+// Checkin $Date: November 6, 2009   16:15:43 $
+//###########################################################################
+//
+// FILE:    DSP2803x_ECan.c
+//
+// TITLE:   DSP2803x Enhanced CAN Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP28 Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP28 Examples Include File
+
+//---------------------------------------------------------------------------
+// InitECan:
+//---------------------------------------------------------------------------
+// This function initializes the eCAN module to a known state.
+//
+void InitECan(void)
+{
+   InitECana();
+}
+
+void InitECana(void)        // Initialize eCAN-A module
+{
+
+/* Create a shadow register structure for the CAN control registers. This is
+ needed, since only 32-bit access is allowed to these registers. 16-bit access
+ to these registers could potentially corrupt the register contents or return
+ false data. */
+
+struct ECAN_REGS ECanaShadow;
+
+    EALLOW;     // EALLOW enables access to protected bits
+
+/* Configure eCAN RX and TX pins for CAN operation using eCAN regs*/
+
+    ECanaShadow.CANTIOC.all = ECanaRegs.CANTIOC.all;
+    ECanaShadow.CANTIOC.bit.TXFUNC = 1;
+    ECanaRegs.CANTIOC.all = ECanaShadow.CANTIOC.all;
+
+    ECanaShadow.CANRIOC.all = ECanaRegs.CANRIOC.all;
+    ECanaShadow.CANRIOC.bit.RXFUNC = 1;
+    ECanaRegs.CANRIOC.all = ECanaShadow.CANRIOC.all;
+
+/* Configure eCAN for HECC mode - (reqd to access mailboxes 16 thru 31) */
+                                    // HECC mode also enables time-stamping feature
+
+    ECanaShadow.CANMC.all = ECanaRegs.CANMC.all;
+    ECanaShadow.CANMC.bit.SCB = 1;
+    ECanaRegs.CANMC.all = ECanaShadow.CANMC.all;
+
+/* Initialize all bits of 'Message Control Register' to zero */
+// Some bits of MSGCTRL register come up in an unknown state. For proper operation,
+// all bits (including reserved bits) of MSGCTRL must be initialized to zero
+
+    ECanaMboxes.MBOX0.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX1.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX2.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX3.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX4.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX5.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX6.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX7.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX8.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX9.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX10.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX11.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX12.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX13.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX14.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX15.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX16.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX17.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX18.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX19.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX20.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX21.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX22.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX23.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX24.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX25.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX26.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX27.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX28.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX29.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX30.MSGCTRL.all = 0x00000000;
+    ECanaMboxes.MBOX31.MSGCTRL.all = 0x00000000;
+
+// TAn, RMPn, GIFn bits are all zero upon reset and are cleared again
+//  as a matter of precaution.
+
+    ECanaRegs.CANTA.all = 0xFFFFFFFF;   /* Clear all TAn bits */
+
+    ECanaRegs.CANRMP.all = 0xFFFFFFFF;  /* Clear all RMPn bits */
+
+    ECanaRegs.CANGIF0.all = 0xFFFFFFFF; /* Clear all interrupt flag bits */
+    ECanaRegs.CANGIF1.all = 0xFFFFFFFF;
+
+/* Configure bit timing parameters for eCANA*/
+
+    ECanaShadow.CANMC.all = ECanaRegs.CANMC.all;
+    ECanaShadow.CANMC.bit.CCR = 1 ;            // Set CCR = 1
+    ECanaRegs.CANMC.all = ECanaShadow.CANMC.all;
+
+    // Wait until the CPU has been granted permission to change the configuration registers
+    do
+    {
+      ECanaShadow.CANES.all = ECanaRegs.CANES.all;
+    } while(ECanaShadow.CANES.bit.CCE != 1 );       // Wait for CCE bit to be set..
+
+    ECanaShadow.CANBTC.all = 0;
+    /* The following block is only for 60 MHz SYSCLKOUT. (30 MHz CAN module clock Bit rate = 1 Mbps
+       See Note at end of file. */
+
+    ECanaShadow.CANBTC.bit.BRPREG = 2;
+    ECanaShadow.CANBTC.bit.TSEG2REG = 1;
+    ECanaShadow.CANBTC.bit.TSEG1REG = 6;
+
+    ECanaShadow.CANBTC.bit.SAM = 1;
+    ECanaRegs.CANBTC.all = ECanaShadow.CANBTC.all;
+
+    ECanaShadow.CANMC.all = ECanaRegs.CANMC.all;
+    ECanaShadow.CANMC.bit.CCR = 0 ;            // Set CCR = 0
+    ECanaRegs.CANMC.all = ECanaShadow.CANMC.all;
+
+    // Wait until the CPU no longer has permission to change the configuration registers
+    do
+    {
+      ECanaShadow.CANES.all = ECanaRegs.CANES.all;
+    } while(ECanaShadow.CANES.bit.CCE != 0 );       // Wait for CCE bit to be  cleared..
+
+/* Disable all Mailboxes  */
+    ECanaRegs.CANME.all = 0;        // Required before writing the MSGIDs
+
+    EDIS;
+}
+
+//---------------------------------------------------------------------------
+// Example: InitECanGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as eCAN pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+// Caution:
+// Only one GPIO pin should be enabled for CANTXA operation.
+// Only one GPIO pin shoudl be enabled for CANRXA operation.
+// Comment out other unwanted lines.
+
+void InitECanGpio(void)
+{
+   InitECanaGpio();
+}
+
+void InitECanaGpio(void)
+{
+   EALLOW;
+
+/* Enable internal pull-up for the selected CAN pins */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO30 = 0;     // Enable pull-up for GPIO30 (CANRXA)
+    GpioCtrlRegs.GPAPUD.bit.GPIO31 = 0;     // Enable pull-up for GPIO31 (CANTXA)
+
+/* Set qualification for selected CAN pins to asynch only */
+// Inputs are synchronized to SYSCLKOUT by default.
+// This will select asynch (no qualification) for the selected pins.
+
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO30 = 3;   // Asynch qual for GPIO30 (CANRXA)
+
+/* Configure eCAN-A pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be eCAN functional pins.
+
+    GpioCtrlRegs.GPAMUX2.bit.GPIO30 = 1;    // Configure GPIO30 for CANRXA operation
+    GpioCtrlRegs.GPAMUX2.bit.GPIO31 = 1;    // Configure GPIO31 for CANTXA operation
+
+    EDIS;
+}
+
+/* Note: Bit timing parameters must be chosen based on the network parameters such as
+   the sampling point desired and the propagation delay of the network. The propagation
+   delay is a function of length of the cable, delay introduced by the
+   transceivers and opto/galvanic-isolators (if any).
+
+   The parameters used in this file must be changed taking into account the above mentioned
+   factors in order to arrive at the bit-timing parameters suitable for a network.
+*/
+
+//===========================================================================
+// End of file.
+//===========================================================================
+
+
+

--- a/DSP2803x_common/source/DSP2803x_ECap.c
+++ b/DSP2803x_common/source/DSP2803x_ECap.c
@@ -1,0 +1,81 @@
+// TI File $Revision: /main/1 $
+// Checkin $Date: December 5, 2008   18:00:55 $
+//###########################################################################
+//
+// FILE:   DSP2803x_ECap.c
+//
+// TITLE:  DSP2803x eCAP Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+//---------------------------------------------------------------------------
+// InitECap:
+//---------------------------------------------------------------------------
+// This function initializes the eCAP(s) to a known state.
+//
+void InitECap(void)
+{
+   // Initialize eCAP1
+
+   //tbd...
+
+}
+
+//---------------------------------------------------------------------------
+// Example: InitECapGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as ECAP pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+// Caution:
+// For each eCAP peripheral
+// Only one GPIO pin should be enabled for ECAP operation.
+// Comment out other unwanted lines.
+
+void InitECapGpio()
+{
+
+   InitECap1Gpio();
+}
+
+void InitECap1Gpio(void)
+{
+   EALLOW;
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+// GpioCtrlRegs.GPAPUD.bit.GPIO5 = 0;      // Enable pull-up on GPIO5 (CAP1)
+   GpioCtrlRegs.GPAPUD.bit.GPIO19 = 0;     // Enable pull-up on GPIO19 (CAP1)
+// GpioCtrlRegs.GPAPUD.bit.GPIO24 = 0;     // Enable pull-up on GPIO24 (CAP1)
+
+// Inputs are synchronized to SYSCLKOUT by default.
+// Comment out other unwanted lines.
+
+// GpioCtrlRegs.GPAQSEL1.bit.GPIO5 = 0;    // Synch to SYSCLKOUT GPIO5 (CAP1)
+   GpioCtrlRegs.GPAQSEL2.bit.GPIO19 = 0;   // Synch to SYSCLKOUT GPIO19 (CAP1)
+// GpioCtrlRegs.GPAQSEL2.bit.GPIO24 = 0;   // Synch to SYSCLKOUT GPIO24 (CAP1)
+/* Configure eCAP-1 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be eCAP1 functional pins.
+// Comment out other unwanted lines.
+
+// GpioCtrlRegs.GPAMUX1.bit.GPIO5 = 3;     // Configure GPIO5 as CAP1
+   GpioCtrlRegs.GPAMUX2.bit.GPIO19 = 3;    // Configure GPIO19 as CAP1
+// GpioCtrlRegs.GPAMUX2.bit.GPIO24 = 1;    // Configure GPIO24 as CAP1
+
+    EDIS;
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_EPwm.c
+++ b/DSP2803x_common/source/DSP2803x_EPwm.c
@@ -1,0 +1,335 @@
+// TI File $Revision: /main/3 $
+// Checkin $Date: November 10, 2009   14:05:11 $
+//###########################################################################
+//
+// FILE:   DSP2803x_EPwm.c
+//
+// TITLE:  DSP2803x EPwm Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_EPwm_defines.h"
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+//---------------------------------------------------------------------------
+// InitEPwm:
+//---------------------------------------------------------------------------
+// This function initializes the EPwm(s) to a known state.
+//
+void InitEPwm(void)
+{
+   // Initialize EPwm1/2/3/4/5/6/7
+
+   //tbd...
+
+}
+
+//---------------------------------------------------------------------------
+// Example: InitEPwmGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as EPwm pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+
+void InitEPwmGpio(void)
+{
+   InitEPwm1Gpio();
+   InitEPwm2Gpio();
+   InitEPwm3Gpio();
+#if DSP28_EPWM4
+   InitEPwm4Gpio();
+#endif // endif DSP28_EPWM4
+#if DSP28_EPWM5
+   InitEPwm5Gpio();
+#endif // endif DSP28_EPWM5
+#if DSP28_EPWM6
+   InitEPwm6Gpio();
+#endif // endif DSP28_EPWM6
+#if DSP28_EPWM7
+   InitEPwm7Gpio();
+#endif // endif DSP28_EPWM7
+}
+
+void InitEPwm1Gpio(void)
+{
+   EALLOW;
+
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO0 = 1;    // Disable pull-up on GPIO0 (EPWM1A)
+    GpioCtrlRegs.GPAPUD.bit.GPIO1 = 1;    // Disable pull-up on GPIO1 (EPWM1B)
+
+/* Configure EPWM-1 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPWM1 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO0 = 1;   // Configure GPIO0 as EPWM1A
+    GpioCtrlRegs.GPAMUX1.bit.GPIO1 = 1;   // Configure GPIO1 as EPWM1B
+
+    EDIS;
+}
+
+void InitEPwm2Gpio(void)
+{
+   EALLOW;
+
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO2 = 1;    // Disable pull-up on GPIO2 (EPWM2A)
+    GpioCtrlRegs.GPAPUD.bit.GPIO3 = 1;    // Disable pull-up on GPIO3 (EPWM2B)
+
+/* Configure EPwm-2 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPWM2 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO2 = 1;   // Configure GPIO2 as EPWM2A
+    GpioCtrlRegs.GPAMUX1.bit.GPIO3 = 1;   // Configure GPIO3 as EPWM2B
+
+    EDIS;
+}
+
+void InitEPwm3Gpio(void)
+{
+   EALLOW;
+
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO4 = 1;    // Disable pull-up on GPIO4 (EPWM3A)
+    GpioCtrlRegs.GPAPUD.bit.GPIO5 = 1;    // Disable pull-up on GPIO5 (EPWM3B)
+
+/* Configure EPwm-3 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPWM3 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO4 = 1;   // Configure GPIO4 as EPWM3A
+    GpioCtrlRegs.GPAMUX1.bit.GPIO5 = 1;   // Configure GPIO5 as EPWM3B
+
+    EDIS;
+}
+
+#if DSP28_EPWM4
+void InitEPwm4Gpio(void)
+{
+   EALLOW;
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO6 = 1;    // Disable pull-up on GPIO6 (EPWM4A)
+    GpioCtrlRegs.GPAPUD.bit.GPIO7 = 1;    // Disable pull-up on GPIO7 (EPWM4B)
+
+/* Configure EPWM-4 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPWM4 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO6 = 1;   // Configure GPIO6 as EPWM4A
+    GpioCtrlRegs.GPAMUX1.bit.GPIO7 = 1;   // Configure GPIO7 as EPWM4B
+
+    EDIS;
+}
+#endif // endif DSP28_EPWM4
+
+#if DSP28_EPWM5
+void InitEPwm5Gpio(void)
+{
+   EALLOW;
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO8 = 1;    // Disable pull-up on GPIO8 (EPWM5A)
+    GpioCtrlRegs.GPAPUD.bit.GPIO9 = 1;    // Disable pull-up on GPIO9 (EPWM5B)
+
+/* Configure EPWM-5 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPWM5 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO8 = 1;   // Configure GPIO8 as EPWM5A
+    GpioCtrlRegs.GPAMUX1.bit.GPIO9 = 1;   // Configure GPIO9 as EPWM5B
+
+    EDIS;
+}
+#endif // endif DSP28_EPWM5
+
+#if DSP28_EPWM6
+void InitEPwm6Gpio(void)
+{
+   EALLOW;
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO10 = 1;    // Disable pull-up on GPIO10 (EPWM6A)
+    GpioCtrlRegs.GPAPUD.bit.GPIO11 = 1;    // Disable pull-up on GPIO11 (EPWM6B)
+
+/* Configure EPWM-6 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPWM6 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO10 = 1;   // Configure GPIO10 as EPWM6A
+    GpioCtrlRegs.GPAMUX1.bit.GPIO11 = 1;   // Configure GPIO11 as EPWM6B
+
+    EDIS;
+}
+#endif // endif DSP28_EPWM6
+
+#if DSP28_EPWM7
+void InitEPwm7Gpio(void)
+{
+   EALLOW;
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPBPUD.bit.GPIO40 = 1;    // Disable pull-up on GPIO40 (EPWM7A)
+    GpioCtrlRegs.GPBPUD.bit.GPIO41 = 1;    // Disable pull-up on GPIO41 (EPWM7B)
+
+/* Configure EPWM-7 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPWM7 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPBMUX1.bit.GPIO40 = 1;   // Configure GPIO40 as EPWM7A
+    GpioCtrlRegs.GPBMUX1.bit.GPIO41 = 1;   // Configure GPIO41 as EPWM7B
+
+    EDIS;
+}
+#endif // endif DSP28_EPWM7
+
+
+//---------------------------------------------------------------------------
+// Example: InitEPwmSyncGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as EPwm Synch pins
+//
+
+void InitEPwmSyncGpio(void)
+{
+
+//   EALLOW;
+
+/* Configure EPWMSYNCI  */
+
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+// GpioCtrlRegs.GPAPUD.bit.GPIO6 = 0;    // Enable pull-up on GPIO6 (EPWMSYNCI)
+   GpioCtrlRegs.GPBPUD.bit.GPIO32 = 0;   // Enable pull-up on GPIO32 (EPWMSYNCI)
+
+/* Set qualification for selected pins to asynch only */
+// This will select synch to SYSCLKOUT for the selected pins.
+// Comment out other unwanted lines.
+
+// GpioCtrlRegs.GPAQSEL1.bit.GPIO6 = 0;   // Synch to SYSCLKOUT GPIO6 (EPWMSYNCI)
+   GpioCtrlRegs.GPBQSEL1.bit.GPIO32 = 0;  // Synch to SYSCLKOUT GPIO32 (EPWMSYNCI)
+
+/* Configure EPwmSync pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be EPwmSync functional pins.
+// Comment out other unwanted lines.
+
+// GpioCtrlRegs.GPAMUX1.bit.GPIO6 = 2;    // Configures GPIO6 for EPWMSYNCI operation
+   GpioCtrlRegs.GPBMUX1.bit.GPIO32 = 2;   // Configures GPIO32 for EPWMSYNCI operation.
+
+/* Configure EPWMSYNC0  */
+
+/* Disable internal pull-up for the selected output pins
+   for reduced power consumption */
+// Pull-ups can be enabled or disabled by the user.
+// Comment out other unwanted lines.
+
+// GpioCtrlRegs.GPAPUD.bit.GPIO6 = 1;    // Disable pull-up on GPIO6 (EPWMSYNCO)
+   GpioCtrlRegs.GPBPUD.bit.GPIO33 = 1;   // Disable pull-up on GPIO33 (EPWMSYNCO)
+
+// GpioCtrlRegs.GPAMUX1.bit.GPIO6 = 3;   // Configures GPIO6 for EPWMSYNCO
+   GpioCtrlRegs.GPBMUX1.bit.GPIO33 = 2;  // Configures GPIO33 for EPWMSYNCO
+
+}
+
+//---------------------------------------------------------------------------
+// Example: InitTzGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as Trip Zone (TZ) pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+
+void InitTzGpio(void)
+{
+   EALLOW;
+
+   /* 启用选定引脚的内部上拉电阻 */
+   // 上拉电阻可以由用户启用或禁用。
+   // 以下代码将为指定的引脚启用上拉电阻。
+   // 注释掉不需要的行。
+   GpioCtrlRegs.GPAPUD.bit.GPIO12 = 0;    // 为 GPIO12 (TZ1) 启用上拉电阻
+   // GpioCtrlRegs.GPAPUD.bit.GPIO15 = 0;    // 为 GPIO15 (TZ1) 启用上拉电阻
+   GpioCtrlRegs.GPAPUD.bit.GPIO13 = 0;    // 为 GPIO13 (TZ2) 启用上拉电阻
+   // GpioCtrlRegs.GPAPUD.bit.GPIO16 = 0;    // 为 GPIO16 (TZ2) 启用上拉电阻
+   // GpioCtrlRegs.GPAPUD.bit.GPIO28 = 0;    // 为 GPIO28 (TZ2) 启用上拉电阻
+   GpioCtrlRegs.GPAPUD.bit.GPIO14 = 0;    // 为 GPIO14 (TZ3) 启用上拉电阻
+   // GpioCtrlRegs.GPAPUD.bit.GPIO17 = 0;    // 为 GPIO17 (TZ3) 启用上拉电阻
+   // GpioCtrlRegs.GPAPUD.bit.GPIO29 = 0;    // 为 GPIO29 (TZ3) 启用上拉电阻
+
+   /* 设置选定引脚的输入资格为异步 */
+   // 输入默认同步到 SYSCLKOUT。
+   // 以下代码将选择异步（无资格）作为选定引脚的输入模式。
+   // 注释掉不需要的行。
+   GpioCtrlRegs.GPAQSEL1.bit.GPIO12 = 3;  // GPIO12 (TZ1) 设置为异步输入
+   // GpioCtrlRegs.GPAQSEL1.bit.GPIO15 = 3;  // GPIO15 (TZ1) 设置为异步输入
+   GpioCtrlRegs.GPAQSEL1.bit.GPIO13 = 3;  // GPIO13 (TZ2) 设置为异步输入
+   // GpioCtrlRegs.GPAQSEL2.bit.GPIO16 = 3;  // GPIO16 (TZ2) 设置为异步输入
+   // GpioCtrlRegs.GPAQSEL2.bit.GPIO28 = 3;  // GPIO28 (TZ2) 设置为异步输入
+   GpioCtrlRegs.GPAQSEL1.bit.GPIO14 = 3;  // GPIO14 (TZ3) 设置为异步输入
+   // GpioCtrlRegs.GPAQSEL2.bit.GPIO17 = 3;  // GPIO17 (TZ3) 设置为异步输入
+   // GpioCtrlRegs.GPAQSEL2.bit.GPIO29 = 3;  // GPIO29 (TZ3) 设置为异步输入
+
+   /* 使用 GPIO 寄存器配置 TZ 引脚 */
+   // 以下代码指定了哪些 GPIO 引脚将作为 TZ 功能引脚使用。
+   // 注释掉不需要的行。
+   GpioCtrlRegs.GPAMUX1.bit.GPIO12 = 1;  // 配置 GPIO12 作为 TZ1
+   // GpioCtrlRegs.GPAMUX1.bit.GPIO15 = 1;  // 配置 GPIO15 作为 TZ1
+   GpioCtrlRegs.GPAMUX1.bit.GPIO13 = 1;  // 配置 GPIO13 作为 TZ2
+   // GpioCtrlRegs.GPAMUX2.bit.GPIO16 = 3;  // 配置 GPIO16 作为 TZ2
+   // GpioCtrlRegs.GPAMUX2.bit.GPIO28 = 3;  // 配置 GPIO28 作为 TZ2
+   GpioCtrlRegs.GPAMUX1.bit.GPIO14 = 1;  // 配置 GPIO14 作为 TZ3
+   // GpioCtrlRegs.GPAMUX2.bit.GPIO17 = 3;  // 配置 GPIO17 作为 TZ3
+   // GpioCtrlRegs.GPAMUX2.bit.GPIO29 = 3;  // 配置 GPIO29 作为 TZ3
+
+   EDIS;
+}
+
+
+
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_EQep.c
+++ b/DSP2803x_common/source/DSP2803x_EQep.c
@@ -1,0 +1,92 @@
+// TI File $Revision: /main/1 $
+// Checkin $Date: December 5, 2008   18:00:59 $
+//###########################################################################
+//
+// FILE:   DSP2803x_EQep.c
+//
+// TITLE:  DSP2803x eQEP Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+//---------------------------------------------------------------------------
+// InitEQep:
+//---------------------------------------------------------------------------
+// This function initializes the eQEP(s) to a known state.
+//
+void InitEQep(void)
+{
+   // Initialize eQEP1
+
+   //tbd...
+
+}
+
+//---------------------------------------------------------------------------
+// Example: InitEQepGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as eQEP pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+// Caution:
+// For each eQEP peripheral
+// Only one GPIO pin should be enabled for EQEPxA operation.
+// Only one GPIO pin should be enabled for EQEPxB operation.
+// Only one GPIO pin should be enabled for EQEPxS operation.
+// Only one GPIO pin should be enabled for EQEPxI operation.
+// Comment out other unwanted lines.
+
+void InitEQepGpio()
+{
+#if DSP28_EQEP1
+   InitEQep1Gpio();
+#endif  // endif DSP28_EQEP1
+}
+
+#if DSP28_EQEP1
+void InitEQep1Gpio(void)
+{
+   EALLOW;
+
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO20 = 0;   // Enable pull-up on GPIO20 (EQEP1A)
+    GpioCtrlRegs.GPAPUD.bit.GPIO21 = 0;   // Enable pull-up on GPIO21 (EQEP1B)
+    GpioCtrlRegs.GPAPUD.bit.GPIO22 = 0;   // Enable pull-up on GPIO22 (EQEP1S)
+    GpioCtrlRegs.GPAPUD.bit.GPIO23 = 0;   // Enable pull-up on GPIO23 (EQEP1I)
+
+// Inputs are synchronized to SYSCLKOUT by default.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO20 = 0;   // Sync to SYSCLKOUT GPIO20 (EQEP1A)
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO21 = 0;   // Sync to SYSCLKOUT GPIO21 (EQEP1B)
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO22 = 0;   // Sync to SYSCLKOUT GPIO22 (EQEP1S)
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO23 = 0;   // Sync to SYSCLKOUT GPIO23 (EQEP1I)
+
+/* Configure eQEP-1 pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be eQEP1 functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX2.bit.GPIO20 = 1;   // Configure GPIO20 as EQEP1A
+    GpioCtrlRegs.GPAMUX2.bit.GPIO21 = 1;   // Configure GPIO21 as EQEP1B
+    GpioCtrlRegs.GPAMUX2.bit.GPIO22 = 1;   // Configure GPIO22 as EQEP1S
+    GpioCtrlRegs.GPAMUX2.bit.GPIO23 = 1;   // Configure GPIO23 as EQEP1I
+
+    EDIS;
+}
+#endif // if DSP28_EQEP1
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_Gpio.c
+++ b/DSP2803x_common/source/DSP2803x_Gpio.c
@@ -1,0 +1,62 @@
+// TI File $Revision: /main/1 $
+// Checkin $Date: December 5, 2008   18:01:01 $
+//###########################################################################
+//
+// FILE:	DSP2803x_Gpio.c
+//
+// TITLE:	DSP2803x General Purpose I/O Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+//---------------------------------------------------------------------------
+// InitGpio:
+//---------------------------------------------------------------------------
+// This function initializes the Gpio to a known (default) state.
+//
+// For more details on configuring GPIO's as peripheral functions,
+// refer to the individual peripheral examples and/or GPIO setup example.
+void InitGpio(void)
+{
+   EALLOW;
+
+   // Each GPIO pin can be:
+   // a) a GPIO input/output
+   // b) peripheral function 1
+   // c) peripheral function 2
+   // d) peripheral function 3
+   // By default, all are GPIO Inputs
+   GpioCtrlRegs.GPAMUX1.all = 0x0000;     // GPIO functionality GPIO0-GPIO15
+   GpioCtrlRegs.GPAMUX2.all = 0x0000;     // GPIO functionality GPIO16-GPIO31
+   GpioCtrlRegs.GPBMUX1.all = 0x0000;     // GPIO functionality GPIO32-GPIO44
+   GpioCtrlRegs.AIOMUX1.all = 0x0000;     // Dig.IO funct. applies to AIO2,4,6,10,12,14
+
+   GpioCtrlRegs.GPADIR.all = 0x0000;      // GPIO0-GPIO31 are GP inputs
+   GpioCtrlRegs.GPBDIR.all = 0x0000;      // GPIO32-GPIO44 are inputs
+   GpioCtrlRegs.AIODIR.all = 0x0000;      // AIO2,4,6,19,12,14 are digital inputs
+
+   // Each input can have different qualification
+   // a) input synchronized to SYSCLKOUT
+   // b) input qualified by a sampling window
+   // c) input sent asynchronously (valid for peripheral inputs only)
+   GpioCtrlRegs.GPAQSEL1.all = 0x0000;    // GPIO0-GPIO15 Synch to SYSCLKOUT
+   GpioCtrlRegs.GPAQSEL2.all = 0x0000;    // GPIO16-GPIO31 Synch to SYSCLKOUT
+   GpioCtrlRegs.GPBQSEL1.all = 0x0000;    // GPIO32-GPIO44 Synch to SYSCLKOUT
+
+   // Pull-ups can be enabled or disabled.
+   GpioCtrlRegs.GPAPUD.all = 0x0000;      // Pullup's enabled GPIO0-GPIO31
+   GpioCtrlRegs.GPBPUD.all = 0x0000;      // Pullup's enabled GPIO32-GPIO44
+   //GpioCtrlRegs.GPAPUD.all = 0xFFFF;    // Pullup's disabled GPIO0-GPIO31
+   //GpioCtrlRegs.GPBPUD.all = 0xFFFF;    // Pullup's disabled GPIO32-GPIO44
+   EDIS;
+
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_I2C.c
+++ b/DSP2803x_common/source/DSP2803x_I2C.c
@@ -1,0 +1,84 @@
+// TI File $Revision: /main/1 $
+// Checkin $Date: December 5, 2008   18:01:02 $
+//###########################################################################
+//
+// FILE:	DSP2803x_I2C.c
+//
+// TITLE:	DSP2803x SCI Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+//---------------------------------------------------------------------------
+// InitI2C:
+//---------------------------------------------------------------------------
+// This function initializes the I2C to a known state.
+//
+void InitI2C(void)
+{
+	// Initialize I2C-A:
+
+	//tbd...
+}
+
+//---------------------------------------------------------------------------
+// Example: InitI2CGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as I2C pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+// Caution:
+// Only one GPIO pin should be enabled for SDAA operation.
+// Only one GPIO pin shoudl be enabled for SCLA operation.
+// Comment out other unwanted lines.
+
+void InitI2CGpio()
+{
+
+   EALLOW;
+
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+	GpioCtrlRegs.GPAPUD.bit.GPIO28 = 0;    // Enable pull-up for GPIO28 (SDAA)
+	GpioCtrlRegs.GPAPUD.bit.GPIO29 = 0;	   // Enable pull-up for GPIO29 (SCLA)
+
+//	GpioCtrlRegs.GPBPUD.bit.GPIO32 = 0;    // Enable pull-up for GPIO32 (SDAA)
+//	GpioCtrlRegs.GPBPUD.bit.GPIO33 = 0;	   // Enable pull-up for GPIO33 (SCLA)
+
+/* Set qualification for selected pins to asynch only */
+// This will select asynch (no qualification) for the selected pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO28 = 3;  // Asynch input GPIO28 (SDAA)
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO29 = 3;  // Asynch input GPIO29 (SCLA)
+
+//	GpioCtrlRegs.GPBQSEL1.bit.GPIO32 = 3;  // Asynch input GPIO32 (SDAA)
+//  GpioCtrlRegs.GPBQSEL1.bit.GPIO33 = 3;  // Asynch input GPIO33 (SCLA)
+
+/* Configure I2C pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be I2C functional pins.
+// Comment out other unwanted lines.
+
+	GpioCtrlRegs.GPAMUX2.bit.GPIO28 = 2;   // Configure GPIO28 for SDAA operation
+	GpioCtrlRegs.GPAMUX2.bit.GPIO29 = 2;   // Configure GPIO29 for SCLA operation
+
+//	GpioCtrlRegs.GPBMUX1.bit.GPIO32 = 1;   // Configure GPIO32 for SDAA operation
+//	GpioCtrlRegs.GPBMUX1.bit.GPIO33 = 1;   // Configure GPIO33 for SCLA operation
+
+    EDIS;
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_Lin.c
+++ b/DSP2803x_common/source/DSP2803x_Lin.c
@@ -1,0 +1,185 @@
+// TI File $Revision: /main/2 $
+// Checkin $Date: April 20, 2009   17:40:49 $
+//###########################################################################
+//
+// FILE:	DSP2803x_Lin.c
+//
+// TITLE:	DSP2803x LIN Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"
+#include "DSP2803x_Examples.h"
+
+//---------------------------------------------------------------------------
+// InitLin:
+//---------------------------------------------------------------------------
+// This function initializes the LIN to a known state.
+//
+
+void InitLin(void)
+{
+   InitLina();
+}
+
+void InitLina(void)
+{
+	EALLOW;
+
+	//Initialize LIN
+
+    //Reset module and release reset.
+    LinaRegs.SCIGCR0.bit.RESET = 0;
+    LinaRegs.SCIGCR0.bit.RESET = 1;
+
+    //LIN into software reset mode
+    LinaRegs.SCIGCR1.bit.SWnRST = 0;
+
+    //Select LIN Mode
+    LinaRegs.SCIGCR1.bit.LINMODE = 1;
+
+    //Configure LIN mode
+
+	LinaRegs.SCIGCR1.bit.CLK_MASTER = 1; 	// 1-->Master, 0-->Slave
+	LinaRegs.SCIGCR1.bit.ADAPT = 0; 		// Fixed baud rate
+	LinaRegs.SCIGCR1.bit.COMMMODE= 0; 		// ID bits 4 and 5 not used for length control
+	LinaRegs.SCIGCR1.bit.CONT = 1; 			// Continue on Emulation suspend
+	LinaRegs.SCIGCR1.bit.CTYPE = 1; 		// LIN 2.0 Enhanced checksum used
+	LinaRegs.SCIGCR1.bit.HGENCTRL = 1; 		// ID match vs LinaRegs.bit.IDSLAVETASKBYTE
+	LinaRegs.SCIGCR1.bit.LOOPBACK = 0; 		// External communication mode
+	LinaRegs.SCIGCR1.bit.MBUFMODE = 1; 		// Buffered mode
+	LinaRegs.SCIGCR1.bit.PARITYENA = 1; 	// Check received ID for parity
+	LinaRegs.SCIGCR1.bit.RXENA = 1; 		// Enable RX pin
+	LinaRegs.SCIGCR1.bit.TXENA = 1; 		// Enable TX pin
+
+	//More LIN configs
+	LinaRegs.SCIGCR2.bit.CC = 1; 			// Validate checksum
+
+	//Set all interrupts to disabled
+    LinaRegs.SCICLEARINT.all 		= 0xFFFFFFFF;
+
+    //Baud Rate Settings - 60MHz device
+
+    LinaRegs.BRSR.bit.SCI_LIN_PSL = 96; 				// 19.2 kbps
+    LinaRegs.BRSR.bit.M = 11;
+    LinaRegs.MBRSR = 92; //20kHz (max autobaud rate)
+
+    //LIN Character Size and Length
+    LinaRegs.SCIFORMAT.bit.LENGTH 	= 0; 	// 8 bit transmission/response
+
+    //SYNC Field Configuration
+    LinaRegs.LINCOMP.bit.SBREAK = 5; 		// Sync break is 13 + 5 = 18 Tbits
+    LinaRegs.LINCOMP.bit.SDEL = 3; 			// Sync delimiter is 1 + 3 = 4 Tbits
+
+    //LIN MASK Configuartion
+    LinaRegs.LINMASK.bit.TXIDMASK = 0xFF; 	// Mask ID so TX match will always happen
+    LinaRegs.LINMASK.bit.RXIDMASK = 0xFF; 	// Mask ID so RX match will always happen
+
+    //IODFT Configuarations
+    LinaRegs.IODFTCTRL.bit.IODFTENA = 0x0; 	// IODFT testing module disabled
+    LinaRegs.IODFTCTRL.bit.LPBENA 	 = 0; 	// IODFT loopback disabled
+
+    //Release	SCI from software reset state - End of Config
+    LinaRegs.SCIGCR1.bit.SWnRST = 1;
+
+	EDIS;
+}
+
+
+//---------------------------------------------------------------------------
+// GenIdParity:
+//---------------------------------------------------------------------------
+// This function generates the ID parity bits and appends them to the ID.
+// Call this function on a desired ID before header generation in master
+// mode when LinaRegs.SCIGCR1.bit.PARITYENA is set.
+//
+Uint16 P0;
+Uint16 P1;
+
+Uint16 GenIdParity(Uint16 id)
+{
+	P0 =  ((id << 6) ^ (id << 5) ^ (id << 4) ^ (id << 2)) & BIT6;
+	P1 = (((id << 6) ^ (id << 4) ^ (id << 3) ^ (id << 2)) & BIT7) ^ BIT7;
+	return id | P0 | P1;
+}
+
+//---------------------------------------------------------------------------
+// Example: InitLinGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as LIN pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+// Caution:
+// Only one GPIO pin should be enabled for LIN TX operation.
+// Only one GPIO pin shoudl be enabled for LIN RX operation.
+// Comment out other unwanted lines.
+
+void InitLinGpio()
+{
+   InitLinaGpio();
+}
+
+void InitLinaGpio()
+{
+   EALLOW;
+
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+
+	GpioCtrlRegs.GPAPUD.bit.GPIO9 = 0;		// Enable pull-up for GPIO9 (LIN TX)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO14 = 0;		// Enable pull-up for GPIO14 (LIN TX)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO18 = 0;    	// Enable pull-up for GPIO18 (LIN TX)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO22 = 0;		// Enable pull-up for GPIO22 (LIN TX)
+
+	GpioCtrlRegs.GPAPUD.bit.GPIO11 = 0;		// Enable pull-up for GPIO11 (LIN RX)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO15 = 0;		// Enable pull-up for GPIO15 (LIN RX)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO19 = 0;	   	// Enable pull-up for GPIO19 (LIN RX)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO23 = 0;		// Enable pull-up for GPIO23 (LIN RX)
+
+/* Set qualification for selected pins to asynch only */
+// Inputs are synchronized to SYSCLKOUT by default.
+// This will select asynch (no qualification) for the selected pins.
+
+	GpioCtrlRegs.GPAQSEL1.bit.GPIO11 = 3;  // Asynch input GPIO11 (LINRXA)
+//	GpioCtrlRegs.GPAQSEL1.bit.GPIO15 = 3;  // Asynch input GPIO15 (LINRXA)
+//	GpioCtrlRegs.GPAQSEL2.bit.GPIO19 = 3;  // Asynch input GPIO19 (LINRXA)
+//	GpioCtrlRegs.GPAQSEL2.bit.GPIO23 = 3;  // Asynch input GPIO23 (LINRXA)
+
+
+/* Configure LIN-A pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be LIN pins.
+// Only one set of pins should be enabled at any time for LIN operation.
+
+	GpioCtrlRegs.GPAMUX1.bit.GPIO9 = 2;    // Configure GPIO9 for LIN TX operation (2-Enable,0-Disable)
+//	GpioCtrlRegs.GPAMUX1.bit.GPIO14 = 2;   // Configure GPIO14 for LIN TX operation (2-Enable,0-Disable)
+//	GpioCtrlRegs.GPAMUX2.bit.GPIO18 = 2;   // Configure GPIO18 for LIN TX operation (2-Enable,0-Disable)
+//	GpioCtrlRegs.GPAMUX2.bit.GPIO22 = 3;   // Configure GPIO19 for LIN TX operation	 (3-Enable,0-Disable)
+
+	GpioCtrlRegs.GPAMUX1.bit.GPIO11 = 2;   // Configure GPIO11 for LIN RX operation	 (2-Enable,0-Disable)
+//	GpioCtrlRegs.GPAMUX1.bit.GPIO15 = 2;   // Configure GPIO15 for LIN RX operation (2-Enable,0-Disable)
+//	GpioCtrlRegs.GPAMUX2.bit.GPIO19 = 2;   // Configure GPIO19 for LIN RX operation (2-Enable,0-Disable)
+//	GpioCtrlRegs.GPAMUX2.bit.GPIO23 = 3;   // Configure GPIO23 for LIN RX operation (3-Enable,0-Disable)
+
+    EDIS;
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================
+
+
+
+
+
+
+
+
+
+

--- a/DSP2803x_common/source/DSP2803x_MemCopy.c
+++ b/DSP2803x_common/source/DSP2803x_MemCopy.c
@@ -1,0 +1,45 @@
+// TI File $Revision: /main/1 $
+// Checkin $Date: December 5, 2008   18:01:05 $
+//###########################################################################
+//
+// FILE:	DSP2803x_MemCopy.c
+//
+// TITLE:	Memory Copy Utility
+//
+// ASSUMPTIONS:
+//
+//          
+//
+// DESCRIPTION:
+//
+//          This function will copy the specified memory contents from
+//          one location to another. 
+// 
+//          Uint16 *SourceAddr        Pointer to the first word to be moved
+//                                    SourceAddr < SourceEndAddr
+//          Uint16* SourceEndAddr     Pointer to the last word to be moved
+//          Uint16* DestAddr          Pointer to the first destination word
+//
+//          No checks are made for invalid memory locations or that the
+//          end address is > then the first start address.
+// 
+//          
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"
+
+void MemCopy(Uint16 *SourceAddr, Uint16* SourceEndAddr, Uint16* DestAddr)
+{
+    while(SourceAddr < SourceEndAddr)
+    { 
+       *DestAddr++ = *SourceAddr++;
+    }
+    return;
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_OscComp.c
+++ b/DSP2803x_common/source/DSP2803x_OscComp.c
@@ -1,0 +1,119 @@
+// TI File $Revision: /main/1 $
+// Checkin $Date: October 30, 2009   13:34:34 $
+//###########################################################################
+//
+// FILE:   DSP2803x_OscComp.c
+//
+// TITLE:  DSP2803x oscillator compensation functions
+//
+// This file contains the functions which adjust the oscillator trim and compensate
+// for frequency drift based on the current temperature sensor reading.
+//
+// This program makes use of variables stored in OTP during factory
+// test.  These OTP locations on pre-TMS devices may not be populated.
+// Ensure that the following memory locations in TI OTP are populated
+// (not 0xFFFF) before use:
+//
+// 0x3D7E90 to 0x3D7EA4
+//
+// Note that these functions pull data from the OTP by calling functions which
+// reside in OTP.  Therefore the OTP wait-states (controlled by
+// FlashRegs.FOTPWAIT.bit.OTPWAIT) will significantly affect the time required
+// to execute these functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"   // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+
+// Useful definitions
+  #define FP_SCALE 32768       // Scale factor for Q15 fixed point numbers (2^15)
+  #define FP_ROUND FP_SCALE/2  // Quantity added to Q15 numbers before converting
+                               // to integer to round the number
+
+//Amount to add to Q16.15 fixed point number to shift from a fine trim range of
+//(-31 to 31) to (1 to 63).  This guarantees that the trim is positive and can
+//therefore be efficiently rounded
+  #define OSC_POSTRIM 32
+  #define OSC_POSTRIM_OFF FP_SCALE*OSC_POSTRIM
+
+//The following functions return reference values stored in OTP.
+
+//Slope used to compensate oscillator 1 (fine trim steps / ADC code). Stored
+//in fixed point Q15 format.
+  #define getOsc1FineTrimSlope() (*(int16 (*)(void))0x3D7E90)()
+//Oscillator 1 fine trim at high temp
+  #define getOsc1FineTrimOffset() (*(int16 (*)(void))0x3D7E93)()
+//Oscillator 1 coarse trim
+  #define getOsc1CoarseTrim() (*(int16 (*)(void))0x3D7E96)()
+
+//Slope used to compensate oscillator 2 (fine trim steps / ADC code). Stored
+//in fixed point Q15 format.
+  #define getOsc2FineTrimSlope() (*(int16 (*)(void))0x3D7E99)()
+//Oscillator 2 fine trim at high temp
+  #define getOsc2FineTrimOffset() (*(int16 (*)(void))0x3D7E9C)()
+//Oscillator 2 coarse trim
+  #define getOsc2CoarseTrim() (*(int16 (*)(void))0x3D7E9F)()
+
+//ADC reading of temperature sensor at reference temperature for compensation
+  #define getRefTempOffset() (*(int16 (*)(void))0x3D7EA2)()
+
+//Define function for later use
+Uint16 GetOscTrimValue(int Coarse, int Fine);
+
+
+// This function uses the temperature sensor sample reading to perform internal oscillator 1 compensation with
+// reference values stored in OTP.
+void Osc1Comp (int16 sensorSample)
+{
+    int16 compOscFineTrim;
+
+    EALLOW;
+    compOscFineTrim = ((sensorSample - getRefTempOffset())*(int32)getOsc1FineTrimSlope()
+                      + OSC_POSTRIM_OFF + FP_ROUND )/FP_SCALE + getOsc1FineTrimOffset() - OSC_POSTRIM;
+    SysCtrlRegs.INTOSC1TRIM.all = GetOscTrimValue(getOsc1CoarseTrim(), compOscFineTrim);
+    EDIS;
+}
+
+// This function uses the temperature sensor sample reading to perform internal oscillator 2 compensation with
+// reference values stored in OTP.
+void Osc2Comp (int16 sensorSample)
+{
+    int16 compOscFineTrim;
+
+    EALLOW;
+    compOscFineTrim = ((sensorSample - getRefTempOffset())*(int32)getOsc2FineTrimSlope()
+                      + OSC_POSTRIM_OFF + FP_ROUND )/FP_SCALE + getOsc2FineTrimOffset() - OSC_POSTRIM;
+    SysCtrlRegs.INTOSC2TRIM.all = GetOscTrimValue(getOsc2CoarseTrim(), compOscFineTrim);
+    EDIS;
+}
+
+//This function packs the coarse and fine trim into
+//the format of the oscillator trim register
+Uint16 GetOscTrimValue(int Coarse, int Fine)
+{
+    Uint16 regValue = 0;
+
+    if(Fine < 0)
+    {
+        regValue = ((-Fine) | 0x20) << 9;
+    }
+    else
+    {
+        regValue = Fine << 9;
+    }
+    if(Coarse < 0)
+    {
+        regValue |= ((-Coarse) | 0x80);
+    }
+    else
+    {
+        regValue |= Coarse;
+    }
+    return regValue;
+}
+

--- a/DSP2803x_common/source/DSP2803x_PieCtrl.c
+++ b/DSP2803x_common/source/DSP2803x_PieCtrl.c
@@ -1,0 +1,84 @@
+// TI 文件版本 $Revision: /main/1 $
+// 提交日期 $Date: December 5, 2008   18:01:06 $
+//###########################################################################
+//
+// 文件名: DSP2803x_PieCtrl.c
+//
+// 标题: DSP2803x 设备 PIE 控制寄存器初始化函数.
+//
+//###########################################################################
+// $TI 发布: 2803x C/C++ 头文件 V1.21 $
+// $发布日期: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // 包含 DSP2803x 设备头文件
+#include "DSP2803x_Examples.h"   // 包含 DSP2803x 示例头文件
+
+//---------------------------------------------------------------------------
+// InitPieCtrl: 
+//---------------------------------------------------------------------------
+// 此函数将 PIE 控制寄存器初始化为已知状态。
+//
+void InitPieCtrl(void)
+{
+    // 禁用 CPU 级别的中断:
+    DINT;
+
+    // 禁用 PIE
+    PieCtrlRegs.PIECTRL.bit.ENPIE = 0;
+
+	// 清除所有 PIEIER 寄存器:
+	PieCtrlRegs.PIEIER1.all = 0;
+	PieCtrlRegs.PIEIER2.all = 0;
+	PieCtrlRegs.PIEIER3.all = 0;	
+	PieCtrlRegs.PIEIER4.all = 0;
+	PieCtrlRegs.PIEIER5.all = 0;
+	PieCtrlRegs.PIEIER6.all = 0;
+	PieCtrlRegs.PIEIER7.all = 0;
+	PieCtrlRegs.PIEIER8.all = 0;
+	PieCtrlRegs.PIEIER9.all = 0;
+	PieCtrlRegs.PIEIER10.all = 0;
+	PieCtrlRegs.PIEIER11.all = 0;
+	PieCtrlRegs.PIEIER12.all = 0;
+
+	// 清除所有 PIEIFR 寄存器:
+	PieCtrlRegs.PIEIFR1.all = 0;
+	PieCtrlRegs.PIEIFR2.all = 0;
+	PieCtrlRegs.PIEIFR3.all = 0;	
+	PieCtrlRegs.PIEIFR4.all = 0;
+	PieCtrlRegs.PIEIFR5.all = 0;
+	PieCtrlRegs.PIEIFR6.all = 0;
+	PieCtrlRegs.PIEIFR7.all = 0;
+	PieCtrlRegs.PIEIFR8.all = 0;
+	PieCtrlRegs.PIEIFR9.all = 0;
+	PieCtrlRegs.PIEIFR10.all = 0;
+	PieCtrlRegs.PIEIFR11.all = 0;
+	PieCtrlRegs.PIEIFR12.all = 0;
+
+}	
+
+//---------------------------------------------------------------------------
+// EnableInterrupts: 
+//---------------------------------------------------------------------------
+// 此函数启用 PIE 模块和 CPU 中断
+//
+void EnableInterrupts()
+{
+
+    // 启用 PIE
+    PieCtrlRegs.PIECTRL.bit.ENPIE = 1;
+    		
+	// 允许 PIE 向 CPU 发送脉冲
+	PieCtrlRegs.PIEACK.all = 0xFFFF;  
+
+	// 启用 CPU 级别的中断 
+    EINT;
+
+}
+
+//===========================================================================
+// 文件结束
+
+
+
+

--- a/DSP2803x_common/source/DSP2803x_PieVect.c
+++ b/DSP2803x_common/source/DSP2803x_PieVect.c
@@ -1,0 +1,207 @@
+// TI File $Revision: /main/3 $
+// Checkin $Date: April 6, 2009   17:03:56 $
+//###########################################################################
+//
+// FILE:	DSP2803x_PieVect.c
+//
+// TITLE:	DSP2803x Devices PIE Vector Table Initialization Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+const struct PIE_VECT_TABLE PieVectTableInit = {
+
+      PIE_RESERVED,  // 0  Reserved space
+      PIE_RESERVED,  // 1  Reserved space
+      PIE_RESERVED,  // 2  Reserved space
+      PIE_RESERVED,  // 3  Reserved space
+      PIE_RESERVED,  // 4  Reserved space
+      PIE_RESERVED,  // 5  Reserved space
+      PIE_RESERVED,  // 6  Reserved space
+      PIE_RESERVED,  // 7  Reserved space
+      PIE_RESERVED,  // 8  Reserved space
+      PIE_RESERVED,  // 9  Reserved space
+      PIE_RESERVED,  // 10 Reserved space
+      PIE_RESERVED,  // 11 Reserved space
+      PIE_RESERVED,  // 12 Reserved space
+
+// Non-Peripheral Interrupts
+      INT13_ISR,     // CPU-Timer 1
+      INT14_ISR,     // CPU-Timer2
+      DATALOG_ISR,   // Datalogging interrupt
+      RTOSINT_ISR,   // RTOS interrupt
+      EMUINT_ISR,    // Emulation interrupt
+      NMI_ISR,       // Non-maskable interrupt
+      ILLEGAL_ISR,   // Illegal operation TRAP
+      USER1_ISR,     // User Defined trap 1
+      USER2_ISR,     // User Defined trap 2
+      USER3_ISR,     // User Defined trap 3
+      USER4_ISR,     // User Defined trap 4
+      USER5_ISR,     // User Defined trap 5
+      USER6_ISR,     // User Defined trap 6
+      USER7_ISR,     // User Defined trap 7
+      USER8_ISR,     // User Defined trap 8
+      USER9_ISR,     // User Defined trap 9
+      USER10_ISR,    // User Defined trap 10
+      USER11_ISR,    // User Defined trap 11
+      USER12_ISR,    // User Defined trap 12
+
+// Group 1 PIE Vectors
+      ADCINT1_ISR,     // 1.1 ADC  // if this is rsvd_ISR, then INT10.1 should be defined as ADCINT1_ISR
+      ADCINT2_ISR,     // 1.2 ADC  // if this is rsvd_ISR, then INT10.2 should be defined as ADCINT2_ISR
+      rsvd_ISR,        // 1.3
+      XINT1_ISR,       // 1.4 External Interrupt
+      XINT2_ISR,       // 1.5 External Interrupt
+      ADCINT9_ISR,     // 1.6 ADC
+      TINT0_ISR,       // 1.7 Timer 0
+      WAKEINT_ISR,     // 1.8 WD, Low Power
+
+// Group 2 PIE Vectors
+      EPWM1_TZINT_ISR, // 2.1 EPWM-1 Trip Zone
+      EPWM2_TZINT_ISR, // 2.2 EPWM-2 Trip Zone
+      EPWM3_TZINT_ISR, // 2.3 EPWM-3 Trip Zone
+      EPWM4_TZINT_ISR, // 2.4 EPWM-4 Trip Zone
+      EPWM5_TZINT_ISR, // 2.4 EPWM-4 Trip Zone
+      EPWM6_TZINT_ISR, // 2.4 EPWM-4 Trip Zone
+      EPWM7_TZINT_ISR, // 2.4 EPWM-4 Trip Zone
+      rsvd_ISR,        // 2.8
+
+// Group 3 PIE Vectors
+      EPWM1_INT_ISR,   // 3.1 EPWM-1 Interrupt
+      EPWM2_INT_ISR,   // 3.2 EPWM-2 Interrupt
+      EPWM3_INT_ISR,   // 3.3 EPWM-3 Interrupt
+      EPWM4_INT_ISR,   // 3.4 EPWM-4 Interrupt
+      EPWM5_INT_ISR,   // 3.5 EPWM-5 Interrupt
+      EPWM6_INT_ISR,   // 3.6 EPWM-6 Interrupt
+      EPWM7_INT_ISR,   // 3.7 EPWM-7 Interrupt
+      rsvd_ISR,        // 3.8
+
+// Group 4 PIE Vectors
+      ECAP1_INT_ISR,   // 4.1 ECAP-1
+      rsvd_ISR,        // 4.2
+      rsvd_ISR,        // 4.3
+      rsvd_ISR,        // 4.4
+      rsvd_ISR,        // 4.5
+      rsvd_ISR,        // 4.6
+      rsvd_ISR,        // 4.7
+      rsvd_ISR,        // 4.8
+
+// Group 5 PIE Vectors
+
+      EQEP1_INT_ISR,   // 5.1 EQEP-1
+      rsvd_ISR,        // 5.2
+      rsvd_ISR,        // 5.3
+      rsvd_ISR,        // 5.4
+      rsvd_ISR,        // 5.5
+      rsvd_ISR,        // 5.6
+      rsvd_ISR,        // 5.7
+      rsvd_ISR,        // 5.8
+
+// Group 6 PIE Vectors
+      SPIRXINTA_ISR,   // 6.1 SPI-A
+      SPITXINTA_ISR,   // 6.2 SPI-A
+      SPIRXINTB_ISR,   // 6.3 SPI-B
+      SPITXINTB_ISR,   // 6.4 SPI-B
+      rsvd_ISR,        // 6.5
+      rsvd_ISR,        // 6.6
+      rsvd_ISR,        // 6.7
+      rsvd_ISR,        // 6.8
+
+// Group 7 PIE Vectors
+      rsvd_ISR,        // 7.1
+      rsvd_ISR,        // 7.2
+      rsvd_ISR,        // 7.3
+      rsvd_ISR,        // 7.4
+      rsvd_ISR,        // 7.5
+      rsvd_ISR,        // 7.6
+      rsvd_ISR,        // 7.7
+      rsvd_ISR,        // 7.8
+
+// Group 8 PIE Vectors
+      I2CINT1A_ISR,    // 8.1 I2C
+      I2CINT2A_ISR,    // 8.2 I2C
+      rsvd_ISR,        // 8.3
+      rsvd_ISR,        // 8.4
+      rsvd_ISR,        // 8.5
+      rsvd_ISR,        // 8.6
+      rsvd_ISR,        // 8.7
+      rsvd_ISR,        // 8.8
+
+// Group 9 PIE Vectors
+      SCIRXINTA_ISR,   // 9.1 SCI-A
+      SCITXINTA_ISR,   // 9.2 SCI-A
+      LIN0INTA_ISR,    // 9.3 LIN-A
+      LIN1INTA_ISR,    // 9.4 LIN-A
+      ECAN0INTA_ISR,   // 9.5 eCAN-A
+      ECAN1INTA_ISR,   // 9.6 eCAN-A
+      rsvd_ISR,        // 9.7
+      rsvd_ISR,        // 9.8
+
+// Group 10 PIE Vectors
+      rsvd_ISR,        // 10.1 If this is ADCINT1_ISR, then INT1.1 should be defined as rsvd_ISR
+      rsvd_ISR,        // 10.2 If this is ADCINT2_ISR, then INT1.2 should be defined as rsvd_ISR
+      ADCINT3_ISR,     // 10.3 ADC
+      ADCINT4_ISR,     // 10.4 ADC
+      ADCINT5_ISR,     // 10.5 ADC
+      ADCINT6_ISR,     // 10.6 ADC
+      ADCINT7_ISR,     // 10.7 ADC
+      ADCINT8_ISR,     // 10.8 ADC
+
+// Group 11 PIE Vectors
+      CLA1_INT1_ISR,   // 11.1 CLA1
+      CLA1_INT2_ISR,   // 11.2 CLA1
+      CLA1_INT3_ISR,   // 11.3 CLA1
+      CLA1_INT4_ISR,   // 11.4 CLA1
+      CLA1_INT5_ISR,   // 11.5 CLA1
+      CLA1_INT6_ISR,   // 11.6 CLA1
+      CLA1_INT7_ISR,   // 11.7 CLA1
+      CLA1_INT8_ISR,   // 11.8 CLA1
+
+// Group 12 PIE Vectors
+      XINT3_ISR,       // 12.1 External Interrupt
+      rsvd_ISR,        // 12.2
+      rsvd_ISR,        // 12.3
+      rsvd_ISR,        // 12.4
+      rsvd_ISR,        // 12.5
+      rsvd_ISR,        // 12.6
+      LVF_ISR,         // 12.7 CLA1
+      LUF_ISR          // 12.8 CLA1
+};
+
+//---------------------------------------------------------------------------
+// InitPieVectTable:
+//---------------------------------------------------------------------------
+// This function initializes the PIE vector table to a known state.
+// This function must be executed after boot time.
+//
+
+void InitPieVectTable(void)
+{
+	int16	i;
+	Uint32 *Source = (void *) &PieVectTableInit;
+	Uint32 *Dest = (void *) &PieVectTable;
+
+	// Do not write over first 3 32-bit locations (these locations are
+	// initialized by Boot ROM with boot variables)
+
+	Source = Source + 3;
+	Dest = Dest + 3;
+
+	EALLOW;
+	for(i=0; i < 125; i++)
+		*Dest++ = *Source++;
+	EDIS;
+
+	// Enable the PIE Vector Table
+	PieCtrlRegs.PIECTRL.bit.ENPIE = 1;
+
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_Sci.c
+++ b/DSP2803x_common/source/DSP2803x_Sci.c
@@ -1,0 +1,84 @@
+// TI File $Revision: /main/1 $
+// Checkin $Date: December 5, 2008   18:01:09 $
+//###########################################################################
+//
+// FILE:	DSP2803x_Sci.c
+//
+// TITLE:	DSP2803x SCI Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+//---------------------------------------------------------------------------
+// InitSci:
+//---------------------------------------------------------------------------
+// This function initializes the SCI(s) to a known state.
+//
+void InitSci(void)
+{
+	// Initialize SCI-A:
+
+	//tbd...
+
+}
+
+//---------------------------------------------------------------------------
+// Example: InitSciGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as SCI pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+// Caution:
+// Only one GPIO pin should be enabled for SCITXDA/B operation.
+// Only one GPIO pin shoudl be enabled for SCIRXDA/B operation.
+// Comment out other unwanted lines.
+
+void InitSciGpio()
+{
+   InitSciaGpio();
+}
+
+void InitSciaGpio()
+{
+   EALLOW;
+
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled disabled by the user.
+// This will enable the pullups for the specified pins.
+
+	GpioCtrlRegs.GPAPUD.bit.GPIO28 = 0;    // Enable pull-up for GPIO28 (SCIRXDA)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO7 = 0;     // Enable pull-up for GPIO7  (SCIRXDA)
+
+	GpioCtrlRegs.GPAPUD.bit.GPIO29 = 0;	   // Enable pull-up for GPIO29 (SCITXDA)
+//	GpioCtrlRegs.GPAPUD.bit.GPIO12 = 0;	   // Enable pull-up for GPIO12 (SCITXDA)
+
+/* Set qualification for selected pins to asynch only */
+// Inputs are synchronized to SYSCLKOUT by default.
+// This will select asynch (no qualification) for the selected pins.
+
+	GpioCtrlRegs.GPAQSEL2.bit.GPIO28 = 3;  // Asynch input GPIO28 (SCIRXDA)
+//	GpioCtrlRegs.GPAQSEL1.bit.GPIO7 = 3;   // Asynch input GPIO7 (SCIRXDA)
+
+/* Configure SCI-A pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be SCI functional pins.
+
+	GpioCtrlRegs.GPAMUX2.bit.GPIO28 = 1;   // Configure GPIO28 for SCIRXDA operation
+//	GpioCtrlRegs.GPAMUX1.bit.GPIO7 = 2;    // Configure GPIO7  for SCIRXDA operation
+
+	GpioCtrlRegs.GPAMUX2.bit.GPIO29 = 1;   // Configure GPIO29 for SCITXDA operation
+//	GpioCtrlRegs.GPAMUX1.bit.GPIO12 = 2;   // Configure GPIO12 for SCITXDA operation
+
+    EDIS;
+}
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_Spi.c
+++ b/DSP2803x_common/source/DSP2803x_Spi.c
@@ -1,0 +1,159 @@
+// TI File $Revision: /main/2 $
+// Checkin $Date: February 24, 2009   15:54:34 $
+//###########################################################################
+//
+// FILE:   DSP2803x_Spi.c
+//
+// TITLE:  DSP2803x SPI Initialization & Support Functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+//---------------------------------------------------------------------------
+// InitSPI:
+//---------------------------------------------------------------------------
+// This function initializes the SPI(s) to a known state.
+//
+void InitSpi(void)
+{
+   // Initialize SPI-A
+
+   //tbd...
+
+}
+
+//---------------------------------------------------------------------------
+// Example: InitSpiGpio:
+//---------------------------------------------------------------------------
+// This function initializes GPIO pins to function as SPI pins
+//
+// Each GPIO pin can be configured as a GPIO pin or up to 3 different
+// peripheral functional pins. By default all pins come up as GPIO
+// inputs after reset.
+//
+// Caution:
+// For each SPI peripheral
+// Only one GPIO pin should be enabled for SPISOMO operation.
+// Only one GPIO pin should be enabled for SPISOMI operation.
+// Only one GPIO pin should be enabled for SPICLK  operation.
+// Only one GPIO pin should be enabled for SPISTE  operation.
+// Comment out other unwanted lines.
+
+void InitSpiGpio()
+{
+
+   InitSpiaGpio();
+ #if DSP28_SPIB
+   InitSpibGpio();
+ #endif // endif DSP28_SPIB
+}
+
+void InitSpiaGpio()
+{
+
+   EALLOW;
+
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO16 = 0;   // Enable pull-up on GPIO16 (SPISIMOA)
+//  GpioCtrlRegs.GPAPUD.bit.GPIO5 = 0;    // Enable pull-up on GPIO5 (SPISIMOA)
+    GpioCtrlRegs.GPAPUD.bit.GPIO17 = 0;   // Enable pull-up on GPIO17 (SPISOMIA)
+//  GpioCtrlRegs.GPAPUD.bit.GPIO3 = 0;    // Enable pull-up on GPIO3 (SPISOMIA)
+    GpioCtrlRegs.GPAPUD.bit.GPIO18 = 0;   // Enable pull-up on GPIO18 (SPICLKA)
+    GpioCtrlRegs.GPAPUD.bit.GPIO19 = 0;   // Enable pull-up on GPIO19 (SPISTEA)
+
+/* Set qualification for selected pins to asynch only */
+// This will select asynch (no qualification) for the selected pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO16 = 3; // Asynch input GPIO16 (SPISIMOA)
+//  GpioCtrlRegs.GPAQSEL1.bit.GPIO5 = 3;  // Asynch input GPIO5 (SPISIMOA)
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO17 = 3; // Asynch input GPIO17 (SPISOMIA)
+//  GpioCtrlRegs.GPAQSEL1.bit.GPIO3 = 3;  // Asynch input GPIO3 (SPISOMIA)
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO18 = 3; // Asynch input GPIO18 (SPICLKA)
+    GpioCtrlRegs.GPAQSEL2.bit.GPIO19 = 3; // Asynch input GPIO19 (SPISTEA)
+
+/* Configure SPI-A pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be SPI functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX2.bit.GPIO16 = 1; // Configure GPIO16 as SPISIMOA
+//  GpioCtrlRegs.GPAMUX1.bit.GPIO5 = 2;  // Configure GPIO5 as SPISIMOA
+    GpioCtrlRegs.GPAMUX2.bit.GPIO17 = 1; // Configure GPIO17 as SPISOMIA
+//  GpioCtrlRegs.GPAMUX1.bit.GPIO3 = 2;  // Configure GPIO3 as SPISOMIA
+    GpioCtrlRegs.GPAMUX2.bit.GPIO18 = 1; // Configure GPIO18 as SPICLKA
+    GpioCtrlRegs.GPAMUX2.bit.GPIO19 = 1; // Configure GPIO19 as SPISTEA
+
+    EDIS;
+}
+
+#if DSP28_SPIB
+void InitSpibGpio()
+{
+   EALLOW;
+
+/* Enable internal pull-up for the selected pins */
+// Pull-ups can be enabled or disabled disabled by the user.
+// This will enable the pullups for the specified pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO12 = 0;     // Enable pull-up on GPIO12 (SPISIMOB)
+//  GpioCtrlRegs.GPAPUD.bit.GPIO24 = 0;     // Enable pull-up on GPIO24 (SPISIMOB)
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO13 = 0;     // Enable pull-up on GPIO13 (SPISOMIB)
+//  GpioCtrlRegs.GPAPUD.bit.GPIO25 = 0;     // Enable pull-up on GPIO25 (SPISOMIB)
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO14 = 0;     // Enable pull-up on GPIO14 (SPICLKB)
+//  GpioCtrlRegs.GPAPUD.bit.GPIO26 = 0;     // Enable pull-up on GPIO26 (SPICLKB)
+
+    GpioCtrlRegs.GPAPUD.bit.GPIO15 = 0;     // Enable pull-up on GPIO15 (SPISTEB)
+//  GpioCtrlRegs.GPAPUD.bit.GPIO27 = 0;     // Enable pull-up on GPIO27 (SPISTEB)
+
+
+/* Set qualification for selected pins to asynch only */
+// This will select asynch (no qualification) for the selected pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAQSEL1.bit.GPIO12 = 3;   // Asynch input GPIO12 (SPISIMOB)
+//  GpioCtrlRegs.GPAQSEL2.bit.GPIO24 = 3;   // Asynch input GPIO24 (SPISIMOB)
+
+    GpioCtrlRegs.GPAQSEL1.bit.GPIO13 = 3;   // Asynch input GPIO13 (SPISOMIB)
+//  GpioCtrlRegs.GPAQSEL2.bit.GPIO25 = 3;   // Asynch input GPIO25 (SPISOMIB)
+
+    GpioCtrlRegs.GPAQSEL1.bit.GPIO14 = 3;   // Asynch input GPIO14 (SPICLKB)
+//  GpioCtrlRegs.GPAQSEL2.bit.GPIO26 = 3;   // Asynch input GPIO26 (SPICLKB)
+
+    GpioCtrlRegs.GPAQSEL1.bit.GPIO15 = 3;   // Asynch input GPIO15 (SPISTEB)
+//  GpioCtrlRegs.GPAQSEL2.bit.GPIO27 = 3;   // Asynch input GPIO27 (SPISTEB)
+
+/* Configure SPI-B pins using GPIO regs*/
+// This specifies which of the possible GPIO pins will be SPI functional pins.
+// Comment out other unwanted lines.
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO12 = 3;    // Configure GPIO12 as SPISIMOB
+//  GpioCtrlRegs.GPAMUX2.bit.GPIO24 = 3;    // Configure GPIO24 as SPISIMOB
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO13 = 3;    // Configure GPIO13 as SPISOMIB
+//  GpioCtrlRegs.GPAMUX2.bit.GPIO25 = 3;    // Configure GPIO25 as SPISOMIB
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO14 = 3;    // Configure GPIO14 as SPICLKB
+//  GpioCtrlRegs.GPAMUX2.bit.GPIO26 = 3;    // Configure GPIO26 as SPICLKB
+
+    GpioCtrlRegs.GPAMUX1.bit.GPIO15 = 3;    // Configure GPIO15 as SPISTEB
+//  GpioCtrlRegs.GPAMUX2.bit.GPIO27 = 3;    // Configure GPIO27 as SPISTEB
+
+    EDIS;
+}
+#endif //endif DSP28_SPIB
+
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_SysCtrl.c
+++ b/DSP2803x_common/source/DSP2803x_SysCtrl.c
@@ -1,0 +1,383 @@
+// TI 文件版本 $Revision: /main/7 $
+// 提交日期 $Date: November 10, 2009   14:05:15 $
+//###########################################################################
+//
+// 文件名: DSP2803x_SysCtrl.c
+//
+// 标题: DSP2803x 设备系统控制初始化和支持函数。
+//
+// 描述:
+//
+//         系统资源的示例初始化。
+//
+//###########################################################################
+// $TI 发布: 2803x C/C++ 头文件 V1.21 $
+// $发布日期: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // 包含设备头文件
+#include "DSP2803x_Examples.h"   // 包含示例子程序头文件
+
+// 需要在 RAM 中运行的函数需要分配到不同的段。该段将通过链接器命令文件映射到加载和运行地址。
+
+#pragma CODE_SECTION(InitFlash, "ramfuncs");
+
+//---------------------------------------------------------------------------
+// InitSysCtrl:
+//---------------------------------------------------------------------------
+// 此函数将系统控制寄存器初始化为已知状态。
+// - 禁用看门狗
+// - 设置 PLLCR 以获得正确的 SYSCLKOUT 频率
+// - 设置高、低频外设时钟的预分频器
+// - 启用外设时钟
+
+void InitSysCtrl(void)
+{
+    // 禁用看门狗
+    DisableDog();
+
+    // *重要*
+    // Device_cal 函数会将 ADC 和振荡器校准值从 TI 保留的 OTP 复制到相应的调整寄存器，
+    // 这个过程在引导 ROM 中自动完成。如果在调试过程中绕过了引导 ROM 代码，则必须调用此函数，
+    // 以便 ADC 和振荡器按照规范工作。在调用此函数之前，必须启用 ADC 的时钟。
+    // 更多信息请参阅设备数据手册和/或 ADC 参考手册。
+
+    EALLOW;
+    SysCtrlRegs.PCLKCR0.bit.ADCENCLK = 1; // 启用 ADC 外设时钟
+    (*Device_cal)();                      // 调用校准函数
+    SysCtrlRegs.PCLKCR0.bit.ADCENCLK = 0; // 恢复 ADC 时钟到原始状态
+    EDIS;
+
+    // 选择内部振荡器 1 作为时钟源（默认），并关闭所有未使用的时钟以节省功耗。
+    IntOsc1Sel();
+
+    // 初始化 PLL 控制：PLLCR 和 CLKINDIV
+    // DSP28_PLLCR 和 DSP28_DIVSEL 在 DSP2803x_Examples.h 中定义
+    InitPll(DSP28_PLLCR,DSP28_DIVSEL);
+
+    // 初始化外设时钟
+    InitPeripheralClocks();
+}
+
+//---------------------------------------------------------------------------
+// 示例: InitFlash:
+//---------------------------------------------------------------------------
+// 此函数初始化 Flash 控制寄存器
+
+//                   注意
+// 此函数必须在 RAM 中执行。在 OTP/Flash 中执行它会导致不可预测的结果
+
+void InitFlash(void)
+{
+    EALLOW;
+    // 启用 Flash 管道模式以提高从 Flash 执行代码的性能。
+    FlashRegs.FOPT.bit.ENPIPE = 1;
+
+    //                注意
+    // 必须由 TI 对给定 CPU 速率下的 Flash 最小等待状态进行表征。
+    // 请参阅数据手册获取最新信息。
+
+    // 设置 Flash 的分页等待状态
+    FlashRegs.FBANKWAIT.bit.PAGEWAIT = 2;
+
+    // 设置 Flash 的随机等待状态
+    FlashRegs.FBANKWAIT.bit.RANDWAIT = 2;
+
+    // 设置 OTP 的等待状态
+    FlashRegs.FOTPWAIT.bit.OTPWAIT = 2;
+
+    //                注意
+    // 仅应使用这些寄存器的默认值
+    FlashRegs.FSTDBYWAIT.bit.STDBYWAIT = 0x01FF;
+    FlashRegs.FACTIVEWAIT.bit.ACTIVEWAIT = 0x01FF;
+    EDIS;
+
+    // 强制刷新流水线，以确保对最后一个配置寄存器的写入在返回之前发生。
+
+    asm(" RPT #7 || NOP");
+}
+
+//---------------------------------------------------------------------------
+// 示例: ServiceDog:
+//---------------------------------------------------------------------------
+// 此函数重置看门狗定时器。
+// 如果应用程序中使用 ServiceDog，请启用此功能
+
+void ServiceDog(void)
+{
+    EALLOW;
+    SysCtrlRegs.WDKEY = 0x0055;
+    SysCtrlRegs.WDKEY = 0x00AA;
+    EDIS;
+}
+
+//---------------------------------------------------------------------------
+// 示例: DisableDog:
+//---------------------------------------------------------------------------
+// 此函数禁用看门狗定时器。
+
+void DisableDog(void)
+{
+    EALLOW;
+    SysCtrlRegs.WDCR = 0x0068;
+    EDIS;
+}
+
+//---------------------------------------------------------------------------
+// 示例: InitPll:
+//---------------------------------------------------------------------------
+// 此函数初始化 PLLCR 寄存器。
+
+void InitPll(Uint16 val, Uint16 divsel)
+{
+    volatile Uint16 iVol;
+
+    // 确保 PLL 不处于跛行模式
+    if (SysCtrlRegs.PLLSTS.bit.MCLKSTS != 0)
+    {
+        EALLOW;
+        // 检测到 OSCCLKSRC1 故障，PLL 处于跛行模式。
+        // 重新启用丢失时钟逻辑。
+        SysCtrlRegs.PLLSTS.bit.MCLKCLR = 1;
+        EDIS;
+        // 替换为适当的 SystemShutdown() 函数调用。
+        asm("        ESTOP0");     // 用于调试目的
+    }
+
+    // 在更改 PLLCR 之前，DIVSEL 必须为 0
+    // 外部复位 XRSn 将其设置为 0，这会使我们进入 1/4 模式
+    if (SysCtrlRegs.PLLSTS.bit.DIVSEL != 0)
+    {
+        EALLOW;
+        SysCtrlRegs.PLLSTS.bit.DIVSEL = 0;
+        EDIS;
+    }
+
+    // 更改 PLLCR
+    if (SysCtrlRegs.PLLCR.bit.DIV != val)
+    {
+        EALLOW;
+        // 在设置 PLLCR 之前关闭丢失时钟检测逻辑
+        SysCtrlRegs.PLLSTS.bit.MCLKOFF = 1;
+        SysCtrlRegs.PLLCR.bit.DIV = val;
+        EDIS;
+
+        // 可选：等待 PLL 锁定。
+        // 在此期间，CPU 将切换到 OSCCLK/2 直到 PLL 稳定。
+        // 一旦 PLL 稳定，CPU 将切换到新的 PLL 值。
+        //
+        // 这个锁定时间由 PLL 锁定计数器监控。
+        //
+        // 代码不需要在此等待 PLL 锁定。
+        // 然而，如果代码执行的是时间关键操作，并且需要正确的时钟锁定，则最好等待切换完成。
+
+        // 等待 PLL 锁定位被设置。
+
+        // 在此循环前禁用看门狗，或在循环内通过 ServiceDog() 喂狗。
+
+        // 取消注释以禁用看门狗
+        DisableDog();
+
+        while(SysCtrlRegs.PLLSTS.bit.PLLLOCKS != 1)
+        {
+            // 取消注释以喂狗
+            // ServiceDog();
+        }
+
+        EALLOW;
+        SysCtrlRegs.PLLSTS.bit.MCLKOFF = 0;
+        EDIS;
+    }
+
+    // 如果切换到 1/2
+    if((divsel == 1)||(divsel == 2))
+    {
+        EALLOW;
+        SysCtrlRegs.PLLSTS.bit.DIVSEL = divsel;
+        EDIS;
+    }
+
+    // 如果切换到 1/1
+    // * 先切换到 1/2 并让电源稳定
+    //   稳定所需的时间取决于系统，这里只是一个示例
+    // * 然后切换到 1/1
+    if(divsel == 3)
+    {
+        EALLOW;
+        SysCtrlRegs.PLLSTS.bit.DIVSEL = 2;
+        DELAY_US(50L);
+        SysCtrlRegs.PLLSTS.bit.DIVSEL = 3;
+        EDIS;
+    }
+}
+
+//---------------------------------------------------------------------------
+// 示例: InitPeripheralClocks:
+//---------------------------------------------------------------------------
+// 此函数初始化外设模块的时钟。
+// 首先设置高、低时钟预分频器
+// 然后启用每个外设的时钟。
+// 为了减少功耗，不使用的外设时钟应保持关闭
+//
+// 注意：如果未启用外设时钟，则无法读取或写入该外设的寄存器
+
+void InitPeripheralClocks(void)
+{
+    EALLOW;
+
+    // LOSPCP 预分频寄存器设置，通常设置为默认值
+
+    GpioCtrlRegs.GPAMUX2.bit.GPIO18 = 3;  // GPIO18 = XCLKOUT
+    SysCtrlRegs.LOSPCP.all = 0x0002;
+
+    // XCLKOUT 到 SYSCLKOUT 的比率。默认情况下 XCLKOUT = 1/4 SYSCLKOUT
+    SysCtrlRegs.XCLK.bit.XCLKOUTDIV = 2;
+
+    // 启用选定外设的时钟。
+    // 如果不使用某个外设，请关闭其时钟以节省功耗。
+    //
+    // 注意：并非所有 2803x 衍生产品都包含所有外设。
+    // 请参阅您所使用设备的数据手册。
+    //
+    // 本函数不是高效的代码示例。
+
+    SysCtrlRegs.PCLKCR0.bit.ADCENCLK = 1;      // ADC
+    SysCtrlRegs.PCLKCR3.bit.COMP1ENCLK = 1;    // COMP1
+    SysCtrlRegs.PCLKCR3.bit.COMP2ENCLK = 1;    // COMP2
+    SysCtrlRegs.PCLKCR3.bit.COMP3ENCLK = 1;    // COMP3
+    SysCtrlRegs.PCLKCR1.bit.ECAP1ENCLK = 1;    // eCAP1
+    SysCtrlRegs.PCLKCR0.bit.ECANAENCLK = 1;    // eCAN-A
+    SysCtrlRegs.PCLKCR1.bit.EQEP1ENCLK = 1;    // eQEP1
+    SysCtrlRegs.PCLKCR1.bit.EPWM1ENCLK = 1;    // ePWM1
+    SysCtrlRegs.PCLKCR1.bit.EPWM2ENCLK = 1;    // ePWM2
+    SysCtrlRegs.PCLKCR1.bit.EPWM3ENCLK = 1;    // ePWM3
+    SysCtrlRegs.PCLKCR1.bit.EPWM4ENCLK = 1;    // ePWM4
+    SysCtrlRegs.PCLKCR1.bit.EPWM5ENCLK = 1;    // ePWM5
+    SysCtrlRegs.PCLKCR1.bit.EPWM6ENCLK = 1;    // ePWM6
+    SysCtrlRegs.PCLKCR1.bit.EPWM7ENCLK = 1;    // ePWM7
+    SysCtrlRegs.PCLKCR0.bit.HRPWMENCLK = 1;    // HRPWM
+    SysCtrlRegs.PCLKCR0.bit.I2CAENCLK = 1;     // I2C
+    SysCtrlRegs.PCLKCR0.bit.LINAENCLK = 1;     // LIN-A
+    SysCtrlRegs.PCLKCR3.bit.CLA1ENCLK = 1;     // CLA1
+    SysCtrlRegs.PCLKCR0.bit.SCIAENCLK = 1;     // SCI-A
+    SysCtrlRegs.PCLKCR0.bit.SPIAENCLK = 1;     // SPI-A
+    SysCtrlRegs.PCLKCR0.bit.SPIBENCLK = 1;     // SPI-B
+
+    SysCtrlRegs.PCLKCR0.bit.TBCLKSYNC = 1;     // 启用 ePWM 内部 TBCLK
+
+    EDIS;
+}
+
+//---------------------------------------------------------------------------
+// 示例: CsmUnlock:
+//---------------------------------------------------------------------------
+// 此函数解锁 CSM。用户必须用当前密码替换 0xFFFF。成功解锁返回 1。
+
+#define STATUS_FAIL          0
+#define STATUS_SUCCESS       1
+
+Uint16 CsmUnlock()
+{
+    volatile Uint16 temp;
+
+    // 使用当前密码加载密钥寄存器。0xFFFF 是虚拟密码。用户应替换为正确的密码。
+
+    EALLOW;
+    CsmRegs.KEY0 = 0xFFFF;
+    CsmRegs.KEY1 = 0xFFFF;
+    CsmRegs.KEY2 = 0xFFFF;
+    CsmRegs.KEY3 = 0xFFFF;
+    CsmRegs.KEY4 = 0xFFFF;
+    CsmRegs.KEY5 = 0xFFFF;
+    CsmRegs.KEY6 = 0xFFFF;
+    CsmRegs.KEY7 = 0xFFFF;
+    EDIS;
+
+    // 执行密码位置的虚拟读取
+    // 如果它们匹配密钥值，CSM 将解锁
+
+    temp = CsmPwl.PSWD0;
+    temp = CsmPwl.PSWD1;
+    temp = CsmPwl.PSWD2;
+    temp = CsmPwl.PSWD3;
+    temp = CsmPwl.PSWD4;
+    temp = CsmPwl.PSWD5;
+    temp = CsmPwl.PSWD6;
+    temp = CsmPwl.PSWD7;
+
+    // 如果 CSM 解锁，返回成功，否则返回失败。
+    if (CsmRegs.CSMSCR.bit.SECURE == 0) return STATUS_SUCCESS;
+    else return STATUS_FAIL;
+}
+
+//---------------------------------------------------------------------------
+// 示例: IntOsc1Sel:
+//---------------------------------------------------------------------------
+// 此函数切换到内部振荡器 1 并关闭所有其他时钟源以最小化功耗
+
+void IntOsc1Sel (void) {
+    EALLOW;
+    SysCtrlRegs.CLKCTL.bit.INTOSC1OFF = 0;
+    SysCtrlRegs.CLKCTL.bit.OSCCLKSRCSEL = 0;  // 时钟源 = INTOSC1
+    SysCtrlRegs.CLKCTL.bit.XCLKINOFF = 1;     // 关闭 XCLKIN
+    SysCtrlRegs.CLKCTL.bit.XTALOSCOFF = 1;    // 关闭 XTALOSC
+    SysCtrlRegs.CLKCTL.bit.INTOSC2OFF = 1;    // 关闭 INTOSC2
+    EDIS;
+}
+
+//---------------------------------------------------------------------------
+// 示例: IntOsc2Sel:
+//---------------------------------------------------------------------------
+// 此函数从外部振荡器切换到内部振荡器 2，并关闭所有其他时钟源以最小化功耗
+// 注意：如果没有外部时钟连接，在从 INTOSC1 切换到 INTOSC2 之前，
+//       必须关闭 EXTOSC 和 XLCKIN
+
+void IntOsc2Sel (void) {
+    EALLOW;
+    SysCtrlRegs.CLKCTL.bit.INTOSC2OFF = 0;     // 启用 INTOSC2
+    SysCtrlRegs.CLKCTL.bit.OSCCLKSRC2SEL = 1;  // 切换到 INTOSC2
+    SysCtrlRegs.CLKCTL.bit.XCLKINOFF = 1;      // 关闭 XCLKIN
+    SysCtrlRegs.CLKCTL.bit.XTALOSCOFF = 1;     // 关闭 XTALOSC
+    SysCtrlRegs.CLKCTL.bit.OSCCLKSRCSEL = 1;   // 切换到内部振荡器 2
+    SysCtrlRegs.CLKCTL.bit.WDCLKSRCSEL = 1;    // 切换看门狗时钟源到 INTOSC2
+    SysCtrlRegs.CLKCTL.bit.INTOSC1OFF = 1;     // 关闭 INTOSC1
+    EDIS;
+}
+//---------------------------------------------------------------------------
+// 示例: XtalOscSel:
+//---------------------------------------------------------------------------
+// 此函数切换到外部晶体振荡器并关闭所有其他时钟源以最小化功耗。
+// 此选项可能不适用于所有设备封装
+
+void XtalOscSel (void)  {
+    EALLOW;
+    SysCtrlRegs.CLKCTL.bit.XTALOSCOFF = 0;     // 启用 XTALOSC
+    SysCtrlRegs.CLKCTL.bit.XCLKINOFF = 1;      // 关闭 XCLKIN
+    SysCtrlRegs.CLKCTL.bit.OSCCLKSRC2SEL = 0;  // 切换到外部时钟
+    SysCtrlRegs.CLKCTL.bit.OSCCLKSRCSEL = 1;   // 切换到外部时钟
+    SysCtrlRegs.CLKCTL.bit.WDCLKSRCSEL = 1;    // 切换看门狗时钟源到外部时钟
+    SysCtrlRegs.CLKCTL.bit.INTOSC2OFF = 1;     // 关闭 INTOSC2
+    SysCtrlRegs.CLKCTL.bit.INTOSC1OFF = 1;     // 关闭 INTOSC1
+    EDIS;
+}
+
+//---------------------------------------------------------------------------
+// 示例: ExtOscSel:
+//---------------------------------------------------------------------------
+// 此函数切换到外部振荡器并关闭所有其他时钟源以最小化功耗。
+
+void ExtOscSel (void)  {
+    EALLOW;
+    SysCtrlRegs.XCLK.bit.XCLKINSEL = 1;       // 1-GPIO19 = XCLKIN, 0-GPIO38 = XCLKIN
+    SysCtrlRegs.CLKCTL.bit.XTALOSCOFF = 1;    // Turn on XTALOSC
+    SysCtrlRegs.CLKCTL.bit.XCLKINOFF = 0;     // Turn on XCLKIN
+    SysCtrlRegs.CLKCTL.bit.OSCCLKSRC2SEL = 0; // Switch to external clock
+    SysCtrlRegs.CLKCTL.bit.OSCCLKSRCSEL = 1;  // Switch from INTOSC1 to INTOSC2/ext clk
+    SysCtrlRegs.CLKCTL.bit.WDCLKSRCSEL = 1;   // Switch Watchdog Clk Src to external clock
+    SysCtrlRegs.CLKCTL.bit.INTOSC2OFF = 1;    // Turn off INTOSC2
+    SysCtrlRegs.CLKCTL.bit.INTOSC1OFF = 1;    // Turn off INTOSC1
+    EDIS;
+}
+//===========================================================================
+// End of file.
+//===========================================================================

--- a/DSP2803x_common/source/DSP2803x_TempSensorConv.c
+++ b/DSP2803x_common/source/DSP2803x_TempSensorConv.c
@@ -1,0 +1,69 @@
+// TI File $Revision: /main/2 $
+// Checkin $Date: November 12, 2009   14:54:24 $
+//###########################################################################
+//
+// FILE:   DSP2803x_TempSensorConv.c
+//
+// TITLE:  DSP2803x ADC Temperature Sensor Conversion Functions
+//
+// This file contains funcions necessary to convert the temperature sensor
+// reading into degrees C or K.
+//
+// This program makes use of variables stored in OTP during factory
+// test on 2803x TMS devices only.
+// These OTP locations on pre-TMS devices may not be populated.
+// Ensure that the following memory locations in TI OTP are populated
+// (not 0xFFFF) before use:
+//
+// 0x3D7E90 to 0x3D7EA4
+//
+// Note that these functions pull data from the OTP by calling functions which
+// reside in OTP.  Therefore the OTP wait-states (controlled by
+// FlashRegs.FOTPWAIT.bit.OTPWAIT) will significantly affect the time required
+// to execute these functions.
+//
+//###########################################################################
+// $TI Release: 2803x C/C++ Header Files V1.21 $
+// $Release Date: December 1, 2009 $
+//###########################################################################
+
+#include "DSP2803x_Device.h"     // DSP2803x Headerfile Include File
+#include "DSP2803x_Examples.h"   // DSP2803x Examples Include File
+
+// Useful definitions
+  #define FP_SCALE 32768       //Scale factor for Q15 fixed point numbers (2^15)
+  #define FP_ROUND FP_SCALE/2  //Added to Q15 numbers before converting to integer to round the number
+
+// Amount to add to Q15 fixed point numbers to shift from Celsius to Kelvin
+// (Converting guarantees number is positive, which makes rounding more efficient)
+  #define KELVIN 273
+  #define KELVIN_OFF FP_SCALE*KELVIN
+
+
+// The folloing pointers to function calls are:
+//Slope of temperature sensor (deg. C / ADC code).  Stored in fixed point Q15 format.
+  #define getTempSlope() (*(int (*)(void))0x3D7E82)()
+//ADC code corresponding to temperature sensor output at 0 deg. C
+  #define getTempOffset() (*(int (*)(void))0x3D7E85)()
+
+//This function uses the reference data stored in OTP to convert the raw temperature
+//sensor reading into degrees C
+//ÎÒ×¢ÊÍµÄ
+/*
+int16 GetTemperatureC(int16 sensorSample)
+{
+    return ((sensorSample - getTempOffset())*(int32)getTempSlope() + FP_ROUND + KELVIN_OFF)/FP_SCALE - KELVIN;
+}
+
+//This function uses the reference data stored in OTP to convert the raw temperature
+//sensor reading into degrees K
+int16 GetTemperatureK(int16 sensorSample)
+{
+    return ((sensorSample - getTempOffset())*(int32)getTempSlope() + FP_ROUND + KELVIN_OFF)/FP_SCALE;
+}
+*/
+
+
+
+
+

--- a/DSP2803x_common/source/DSP2803x_usDelay.asm
+++ b/DSP2803x_common/source/DSP2803x_usDelay.asm
@@ -1,0 +1,75 @@
+;// TI File $Revision: /main/1 $
+;// Checkin $Date: December 5, 2008   18:01:17 $
+;//###########################################################################
+;//
+;// FILE:  DSP2803x_usDelay.asm
+;//
+;// TITLE: Simple delay function
+;//
+;// DESCRIPTION:
+;//  
+;// This is a simple delay function that can be used to insert a specified
+;// delay into code.  
+;// 
+;// This function is only accurate if executed from internal zero-waitstate
+;// SARAM. If it is executed from waitstate memory then the delay will be
+;// longer then specified. 
+;// 
+;// To use this function:
+;//
+;//  1 - update the CPU clock speed in the DSP2803x_Examples.h
+;//    file. For example:
+;//    #define CPU_RATE 16.667L // for a 60MHz CPU clock speed
+;//
+;//  2 - Call this function by using the DELAY_US(A) macro
+;//    that is defined in the DSP2803x_Device.h file.  This macro
+;//    will convert the number of microseconds specified
+;//    into a loop count for use with this function.  
+;//    This count will be based on the CPU frequency you specify.
+;//
+;//  3 - For the most accurate delay 
+;//    - Execute this function in 0 waitstate RAM.  
+;//    - Disable interrupts before calling the function
+;//      If you do not disable interrupts, then think of
+;//      this as an "at least" delay function as the actual
+;//      delay may be longer. 
+;//
+;//  The C assembly call from the DELAY_US(time) macro will
+;//  look as follows: 
+;//
+;//  extern void Delay(long LoopCount);                
+;//
+;//        MOV   AL,#LowLoopCount
+;//        MOV   AH,#HighLoopCount
+;//        LCR   _Delay
+;//
+;//  Or as follows (if count is less then 16-bits):
+;//
+;//        MOV   ACC,#LoopCount
+;//        LCR   _Delay
+;//
+;//
+;//###########################################################################
+;// $TI Release: 2803x C/C++ Header Files V1.21 $
+;// $Release Date: December 1, 2009 $
+;//###########################################################################	
+
+       .def _DSP28x_usDelay
+       .sect "ramfuncs"
+
+        .global  __DSP28x_usDelay
+_DSP28x_usDelay:
+        SUB    ACC,#1
+        BF     _DSP28x_usDelay,GEQ    ;; Loop if ACC >= 0
+        LRETR 
+
+;There is a 9/10 cycle overhead and each loop
+;takes five cycles. The LoopCount is given by
+;the following formula:
+;  DELAY_CPU_CYCLES = 9 + 5*LoopCount
+; LoopCount = (DELAY_CPU_CYCLES - 9) / 5
+; The macro DELAY_US(A) performs this calculation for you
+;
+;//===========================================================================
+;// End of file.
+;//===========================================================================

--- a/DSP2803x_headers/include/DSP2803x_EPwm.h
+++ b/DSP2803x_headers/include/DSP2803x_EPwm.h
@@ -570,14 +570,6 @@ extern volatile struct EPWM_REGS EPwm7Regs;
 
 
 
-interrupt void epwm1_timer_isr(void);
-interrupt void epwm2_timer_isr(void);
-void EPWM1_Init(Uint16 tbprd);
-void EPwm1A_SetCompare(Uint16 val);
-void EPwm1B_SetCompare(Uint16 val);
-void EPWM2_Init(Uint16 tbprd);
-void EPwm2A_SetCompare(Uint16 val);
-void EPwm2B_SetCompare(Uint16 val);
 #ifdef __cplusplus
 }
 #endif /* extern "C" */

--- a/SCI/sci.c
+++ b/SCI/sci.c
@@ -1,0 +1,520 @@
+#include "sci.h"
+#include "DSP2803x_Sci.h"
+#include "time.h"
+//串口的波特率是由SCIHBAUD、SCILBAUD组成的一个16位寄存器BRR和LSPCLK低速外设时钟共同决定的
+//它们的关系是:SCI Buad(波特率) = LSPCLK / [(BRR +1)*8],反推之即:BRR = (LSPCLK/Buad*8) - 1
+//同时要注意,如果BRR = 0,那么Buad = LSPCLK/16.
+//其中LSPCLK是主时钟分频得到的,本示例中主时钟为60M,低速时钟分频寄存器为0x02,对应4分频,
+//即LSPCLK为60/4=15MHZ(请查阅InitSysCtrl()函数了解相关时钟寄存器的配置过程)
+
+//TX_INT_EN为1使能发送中断,为0不使能发送中断
+#define TX_INT_EN           0
+#define SCI_FIFO_EN         1  //使能FIFO，若不是用写0
+
+interrupt void USARTA_RxIntHandler(void);       //接收中断中断函数
+#if TX_INT_EN       > 0
+    interrupt void USARTA_TxIntHandler(void);   //发送中断中断函数
+#endif
+
+#define USART1_RX_LENGTH_MAX 200
+
+//中断接收用的标志和缓存变量定义
+Uint16    usart1_rx_length = 0;
+Uint16   Frame_Length = 0;
+Uint16  COM1_RxBuff[USART1_RX_LENGTH_MAX]={0};//Uint16 COM1_RxBuff[15]={0}
+Uint16  COM1_TxBuff[USART1_RX_LENGTH_MAX]={0};//int8（f103）没有八位寄存器
+Uint32  Gu32_modbus_outputIO[USART1_RX_LENGTH_MAX];
+Uint16  Gu16_modbus_bits_outputIO[USART1_RX_LENGTH_MAX];
+
+
+unsigned int    time_usart1,time_usart2;
+
+
+/**
+ * @brief USARTA接收中断处理函数
+ */
+interrupt void USARTA_RxIntHandler(void)
+{
+    Uint16 rev=0;
+#if (SCI_FIFO_EN>0)
+{
+    SciaRegs.SCIFFRX.bit.RXFFINTCLR=1;      // Clear Interrupt flag
+    PieCtrlRegs.PIEACK.all = PIEACK_GROUP9;
+
+    if(SciaRegs.SCIFFRX.bit.RXFFOVF == 0)//接收FIFO未溢出
+    {
+        //接收串口数据
+        while(SciaRegs.SCIFFRX.bit.RXFFST)
+        {
+            rev = SciaRegs.SCIRXBUF.all;//从接收寄存器中取出数据
+
+            USART_Transmit(rev);
+//            //接收到字符 '0' D400状态翻转；接收到字符 '1'，D401翻转
+//            if(rev == '0')
+//                {D400TOGGLE();}
+//            else if(rev == '1')
+//                {D401TOGGLE();}
+        }
+    }
+    else
+    {
+        //用户这里做串口硬件溢出的处理,可以完全读取出FIFO里的数据或者清空FIFO
+        //这里清空FIFO操作
+        SciaRegs.SCIFFRX.bit.RXFFOVRCLR=1;   // Clear HW Overflow flag
+        SciaRegs.SCIFFRX.bit.RXFIFORESET = 0;  //Write 0 to reset the FIFO pointer to zero, and hold in reset.
+        SciaRegs.SCIFFRX.bit.RXFIFORESET = 1 ; //Re-enable receive FIFO operation
+    }
+}
+
+#else
+{
+    // 检查接收缓冲器是否准备好
+    if((SciaRegs.SCIRXST.bit.RXRDY) == 1)
+    {
+        // 重置时间戳
+        time_usart1 = 0;
+        // 将接收到的数据存储到缓冲区中
+        COM1_RxBuff[usart1_rx_length] = SciaRegs.SCIRXBUF.all;
+//        rev= SciaRegs.SCIRXBUF.all ;
+//        USART_Transmit(rev);
+
+         //如果接收的数据长度未超过最大值，则增加长度计数
+        if(usart1_rx_length < USART1_RX_LENGTH_MAX)//Frame_Length
+        {
+            usart1_rx_length ++;
+        }
+    }
+        PieCtrlRegs.PIEACK.bit.ACK9 = 1;
+}
+
+#endif
+}
+
+
+
+#if TX_INT_EN       > 0
+//如果使能了发送中断,该中断服务函数需要根据需要添加用户代码
+interrupt void USARTA_TxIntHandler(void)
+{
+    Uint16 data = 0xAA;
+
+    SciaRegs.SCITXBUF = data;               //模拟发送一个数据
+    PieCtrlRegs.PIEACK.bit.ACK9 = 1;        // Issue PIE ack
+}
+#endif
+
+void USARTA_Init(Uint32 baud)
+{
+    #if (SCI_FIFO_EN >0)
+    {
+        USARTA_Init2(baud);
+    }
+    #else
+    {
+        USARTA_Init1(baud);
+    }
+    #endif
+}
+
+
+/**
+ * @brief 无FIFO初始化USARTA模块
+ * @param buad 波特率
+ */
+void USARTA_Init1(Uint32 baud)
+{
+    // 计算波特率寄存器的值，公式中的1875000是基于系统时钟计算得出的参考值
+    Uint16 brr_reg = (1875000/baud) - 1;    //15000000/8 = 1875000  //12000000/8=1500000
+
+    // 初始化USARTA使用的GPIO端口
+    InitSciaGpio();
+
+    // 配置串口数据格式：1个停止位，无环回模式，无奇偶校验，8个数据位，异步模式，空闲线协议
+    SciaRegs.SCICCR.all =0x0007;
+
+    // 使能TX、RX和内部SCICLK，禁用RX ERR、SLEEP和TXWAKE
+    SciaRegs.SCICTL1.all =0x0003;
+    // 配置控制寄存器2的相关位
+    SciaRegs.SCICTL2.all =0x0003;
+
+    // 根据宏定义决定是否使能发送中断
+#if TX_INT_EN       > 0
+    SciaRegs.SCICTL2.bit.TXINTENA =1;       // 使能发送中断
+#else
+    SciaRegs.SCICTL2.bit.TXINTENA =0;       // 禁止发送中断
+#endif
+    SciaRegs.SCICTL2.bit.RXBKINTENA =1;       // 使能接收中断
+
+    // 设置波特率寄存器的高8位和低8位
+    SciaRegs.SCIHBAUD    =(brr_reg>>8)&0x00FF;
+    SciaRegs.SCILBAUD    =brr_reg&0x00FF;
+    SciaRegs.SCICTL1.all = 0x0023;  // Relinquish SCI from Reset
+
+    // 配置PIE中断
+    EALLOW;
+    PieVectTable.SCIRXINTA= &USARTA_RxIntHandler;
+#if TX_INT_EN       > 0
+    PieVectTable.SCITXINTA = &USARTA_TxIntHandler;
+#endif
+    EDIS;
+
+    // 使能PIE中断
+    PieCtrlRegs.PIECTRL.bit.ENPIE = 1;      // Enable the PIE block
+    PieCtrlRegs.PIEIER9.bit.INTx1=1;        // PIE Group 9, INT1
+#if TX_INT_EN       > 0
+    PieCtrlRegs.PIEIER9.bit.INTx2=1;        // PIE Group 9, INT2
+#endif
+    IER |= M_INT9;                          // Enable CPU INT
+}
+
+
+
+/**
+ * @brief 有FIFO初始化USARTA模块
+ * @param buad 波特率
+ */
+void USARTA_Init2(Uint32 baud)
+{
+    // 计算波特率寄存器的值，公式中的1875000是基于系统时钟计算得出的参考值
+       Uint16 brr_reg = (1875000/baud) - 1;    //15000000/8 = 1875000  //12000000/8=1500000
+       InitSciaGpio();//init sci gpio
+       SciaRegs.SCICTL1.bit.SWRESET = 0;
+
+       SciaRegs.SCICCR.all =0x0007;        // 1 stop bit,  No loopback
+                                           // No parity,8 char bits,无校验位
+                                           // 8个数据位
+       // 设置波特率寄存器的高8位和低8位
+       SciaRegs.SCIHBAUD    =(brr_reg>>8)&0x00FF;
+       SciaRegs.SCILBAUD    =brr_reg&0x00FF;
+
+       SciaRegs.SCICTL1.bit.SWRESET = 1;     // Relinquish SCI from Reset
+       SciaRegs.SCIFFTX.bit.SCIRST=1;
+
+       SciaRegs.SCIFFRX.bit.RXFFIL  = 1;  //设置FIFO深度
+
+       SciaRegs.SCICTL1.all |=0x0003;      // enable TX, RX, internal SCICLK,
+                                           // Disable RX ERR, SLEEP, TXWAKE
+
+       SciaRegs.SCIFFTX.bit.SCIFFENA = 1;      //使能FIFO中断
+       SciaRegs.SCIFFRX.bit.RXFFIENA=1;
+
+       //interrupt isr
+       EALLOW;
+       PieVectTable.SCIRXINTA= &USARTA_RxIntHandler;
+       //PieVectTable.SCITXINTA = &&UARTA_Txisr;
+       EDIS;
+       //sci interrupt in pie group 9.1(rx_ini) or 9.2(tx_int)
+       PieCtrlRegs.PIEIER9.bit.INTx1=1;        // PIE Group 9, RX_INT1
+       //PieCtrlRegs.PIEIER9.bit.INTx2=1;      // PIE Group 9, TX_INT2 DISEN
+       IER |= M_INT9;                          // Enable CPU INT
+       SciaRegs.SCIFFCT.all=0x00;
+       SciaRegs.SCIFFTX.bit.TXFIFOXRESET=1;
+       SciaRegs.SCIFFRX.bit.RXFIFORESET=1;
+}
+
+
+
+/**
+ * 发送一个字节
+ * @param data 要传输的数据，类型为Uint16，表示16位无符号整数
+ */
+void USART_Transmit(Uint16 data)
+{
+    while (SciaRegs.SCICTL2.bit.TXRDY == 0)
+    {
+        ;
+    }
+    SciaRegs.SCITXBUF = data;
+}
+
+
+/**
+ * USART_GetChar函数用于从一个数组中读取一帧数据，并检查是否接收到一帧完整的数据。
+ * 此函数首先检查传入的帧长度是否与之前的不同，如果不同则更新帧长度。
+ * 然后检查当前接收到的数据长度是否等于帧长度，如果相等，表示接收到一帧完整的数据，
+ * 将这些数据复制到用户提供的数组中，并重置接收到的数据长度计数器，最后返回1表示成功。
+ * 如果接收到的数据长度不等于帧长度，则返回0，表示没有接收到完整的一帧数据。
+ */
+Uint16 USART_GetChar(Uint16* p_array, Uint16 frame_len)
+{
+    Uint16 i = 0;
+    // 检查并更新帧长度
+    if(Frame_Length != frame_len)
+    {
+        Frame_Length = frame_len;
+    }
+    // 检查是否接收到一帧完整的数据
+    if(usart1_rx_length == Frame_Length)
+    {
+        // 将接收到的数据复制到用户提供的数组中
+        for(i=0; i< Frame_Length; i++)
+        {
+            p_array[i] = COM1_RxBuff[i];
+        }
+        // 重置接收到的数据长度计数器
+        usart1_rx_length = 0;
+        // 返回1表示成功接收到一帧完整的数据
+        return 1;
+    }
+    // 返回0表示没有接收到完整的一帧数据
+    return 0;
+}
+
+
+/**
+ * 从USART接收的数据中恢复速率信息。
+ * 本函数通过USART接收一帧数据，然后检查数据的完整性与有效性。如果数据有效，则解析出速率信息和命令字节。
+ * @param p_rate 指向一个int32变量的指针，用于存储解析后的速率值。
+ */
+Uint16 USART_GetRate(int32* p_rate)
+{
+    // 用于临时存储接收到的USART数据的数组，包含9个无符号短整型元素。
+    Uint16 temp_array[9] = {0};
+    // 用于循环的计数器变量。
+    Uint16 i =0;
+    // 用于临时计算速率值的变量。
+    int32 temp_rate = 0;
+    // 用于存储命令字节的变量。
+    Uint16 ch_cmd = 0;
+    
+    // 检查是否成功接收到新数据，如果接收到则进行数据校验与恢复，这样提高了查询速度。
+    if(USART_GetChar(temp_array, 9))
+    {
+        // 检查接收到的数据帧的起始和结束标志是否正确，以确保数据的完整性。
+        if((temp_array[0] == 0xaa)&&(temp_array[8] == 0x55))
+        {
+            // 从接收到的数据帧中恢复速率值，数据分布在第4到第7个字节中。
+            for(i = 3; i < 7; i ++)
+            {
+                // 通过位操作将分散的字节组合成完整的速率值。
+                temp_rate |= temp_array[i]<<((i-3)<<3);//8*(i-3)
+            }
+            // 获取命令字节，即数据帧中的第3个字节。
+            ch_cmd = temp_array[2];
+            // 将恢复的速率值存储到通过参数传递的地址中。
+            *p_rate = temp_rate;
+        }
+    }
+    // 返回命令字节，作为速率值的附加信息。
+    return ch_cmd;
+}
+
+
+void USART1_SendString(char *msg)
+{
+    int i=0;
+    // 循环发送字符串中的每个字符，直到遇到字符串结束符'\0'
+    while(msg[i] != '\0')
+    {
+        // 调用USART_Transmit函数发送当前字符
+        USART_Transmit(msg[i]);
+        // 索引变量自增，指向下一个字符
+        i++;
+    }
+}
+
+
+void Usart1_Send_String(Uint16 *buff,Uint16 len)
+{
+    Uint16 t;
+    for(t=0;t<len;t++)
+    {
+        while((SciaRegs.SCIRXST.bit.RXRDY) == 1);
+        USART_Transmit(buff[t]);
+    }
+}
+
+
+void USART_SendString(char *p_STR)
+{
+    while(*p_STR)
+    {
+        USART_Transmit(*p_STR ++);
+    }
+}
+
+//测试用
+//void USART_Debug(Uint16 debug_data)
+//{
+//    USART_Transmit(0xaa);
+//    USART_Transmit(debug_data);
+//    USART_Transmit(0x55);
+//}
+
+
+/**
+ * 通过USART发送一行数据
+ * 
+ * 该函数将一个32位的数据分解成多个字节，并按照一定的格式通过USART发送出去
+ * 在发送数据之前，会计算一个校验和（ch_XOR），以确保数据的完整性
+ * 
+ * @param Data 要发送的32位数据
+ * @param Is_H 标志位，指示是否先发送高字节
+ * @param Line_ID 线路ID，用于标识不同的线路
+ */
+void USART_SendLine(int32 Data ,Uint16 Is_H,Uint16 Line_ID)
+{
+    Uint16 Temp_A_L;
+    Uint16 Temp_A_H;
+    Uint16 Temp_B_L;
+    int16 Temp_B_H;
+
+    Uint16 ch_XOR = 0;
+
+    // 将32位数据分解成4个字节
+    Temp_A_L = Data;
+    Temp_A_H = Data >> 8;
+    Temp_B_L = Data >> 16;
+    Temp_B_H = Data >> 24;
+
+    // 计算校验和
+    ch_XOR ^= 0x09;
+    ch_XOR ^= Line_ID;
+
+    ch_XOR ^= Temp_B_H;
+    ch_XOR ^= Temp_B_L;
+    ch_XOR ^= Temp_A_H;
+    ch_XOR ^= Temp_A_L;
+
+    // 发送固定格式的起始字节
+    USART_Transmit(0xaa);
+    USART_Transmit(0x09);
+    USART_Transmit(Line_ID);
+
+    // 根据Is_H标志决定发送字节的顺序
+    if(Is_H)                            // 是否是先发高字节？
+    {
+        USART_Transmit(Temp_B_H);       // 是
+        USART_Transmit(Temp_B_L);
+        USART_Transmit(Temp_A_H);
+        USART_Transmit(Temp_A_L);
+    }
+    else
+    {
+        USART_Transmit(Temp_A_L);       // 不是
+        USART_Transmit(Temp_A_H);
+        USART_Transmit(Temp_B_L);
+        USART_Transmit(Temp_B_H);
+    }
+
+    // 发送校验和及固定格式的结束字节
+    USART_Transmit(ch_XOR);
+    USART_Transmit(0x55);
+}
+
+
+//////////////发送///////////////////
+#define PRINT_HEX_EN        1
+
+#if PRINT_HEX_EN        > 0
+/////////////////////////////////////////////////////////////////////
+//调试用串口打印函数
+# define UartPutChar    USART_Transmit
+# define Printc         USART_Transmit
+
+/********************************************************************
+函数功能：发送一个字符串。
+入口参数：pd：要发送的字符串指针。
+返    回：无。
+备    注：无。
+********************************************************************/
+void Prints(const void * pstr)
+{
+    Uint16* pd = (Uint16*)pstr;
+    while((*pd)!='\0') //发送字符串，直到遇到0才结束
+    {
+        UartPutChar(*pd); //发送一个字符
+        pd++;  //移动到下一个字符
+    }
+}
+
+////////////////////////End of function//////////////////////////////
+/********************************************************************
+函数功能：将整数转按十进制字符串发送。
+入口参数：x：待显示的整数。
+返    回：无。
+备    注：无。
+********************************************************************/
+void PrintLongInt(Uint32 x)
+{
+    int16 i;
+    Uint16 display_buffer[10];
+
+    for(i=9;i>=0;i--)
+    {
+        display_buffer[i]='0'+x%10;
+        x/=10;
+    }
+    for(i=0;i<9;i++)
+    {
+        if(display_buffer[i]!='0')
+        {
+            break;
+        }
+    }
+    for(;i<10;i++)
+    {
+        UartPutChar(display_buffer[i]);
+    }
+}
+
+////////////////////////End of function//////////////////////////////
+
+
+
+const Uint16 HexTable[]={'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+/********************************************************************
+函数功能：将短整数按十六进制发送。
+入口参数：待发送的整数。
+返    回：无。
+备    注：无。
+********************************************************************/
+void PrintShortIntHex(Uint16 x)
+{
+    Uint16 i;
+    Uint16 display_buffer[7];
+    display_buffer[6]=0;
+    display_buffer[0]='0';
+    display_buffer[1]='x';
+    for(i=5;i>=2;i--) //将整数转换为4个字节的HEX值
+    {
+        display_buffer[i]=HexTable[(x&0xf)];
+        x>>=4;
+    }
+    Prints(display_buffer);
+}
+
+
+
+
+/********************************************************************
+*函数功能：以HEX格式发送一个byte的数据。
+*入口参数：待发送的数据
+ * 打印一个16位无符号整数的十六进制表示
+ * 
+ * 此函数将一个16位无符号整数转换为十六进制格式，并通过调用Printc函数逐字符打印出来
+ * 它首先打印出"0x"前缀，然后将输入的整数分为高4位和低4位，分别转换为对应的十六进制字符并打印
+ * 最后打印一个空格字符，用于格式间隔
+ * 
+ * @param x 16位无符号整数，将被转换为十六进制并打印
+ */
+void PrintHex(Uint16 x)
+{
+    // 打印十六进制表示的前缀"0x"
+    Printc('0');
+    Printc('x');
+    
+    // 将输入的整数的高4位转换为对应的十六进制字符并打印
+    Printc(HexTable[x>>4]);
+    
+    // 将输入的整数的低4位转换为对应的十六进制字符并打印
+    Printc(HexTable[x&0xf]);
+    
+    // 打印一个空格字符，用于格式间隔
+    Printc(' ');
+}
+#endif
+
+
+
+

--- a/SCI/sci.h
+++ b/SCI/sci.h
@@ -1,0 +1,42 @@
+#ifndef SCI_H_
+#define SCI_H_
+
+#include "DSP28x_Project.h"
+#include "tim.h"
+
+#define USART1_RX_LENGTH_MAX 200
+
+extern unsigned int     usart1_rx_length;           //COM1_RxBuff[Index]
+extern Uint16   COM1_RxBuff[USART1_RX_LENGTH_MAX];
+extern Uint16   COM1_TxBuff[USART1_RX_LENGTH_MAX];
+extern Uint32  Gu32_modbus_outputIO[USART1_RX_LENGTH_MAX];
+extern Uint16  Gu16_modbus_bits_outputIO[USART1_RX_LENGTH_MAX];
+extern unsigned int     time_usart1;
+
+void USARTA_Init(Uint32 baud);
+void USARTA_Init1(Uint32 baud);
+void USARTA_Init2(Uint32 baud);
+
+void USART_Transmit(Uint16 data);
+void tscia_fifo_init1(void);
+void scia_xmit(int a);
+void scia_msg(char *msg);
+
+
+Uint16 USART_GetChar(Uint16* p_array, Uint16 frame_len);
+Uint16 USART_GetRate(int32* p_rate);
+
+//数字或字符打印函数
+void PrintHex(Uint16 x);
+void PrintShortIntHex(Uint16 x);
+void PrintLongInt(Uint32 x);
+void Prints(const void * pd);
+
+//void USART1_SendByte(Uint16 a);
+void Usart1_Send_String(Uint16 *buff,Uint16 len);
+void USART1_SendString(char *msg);
+void USART_SendString(char *p_STR);
+void USART_SendLine(int32 Data ,Uint16 Is_H,Uint16 Line_ID);
+void USART_Debug(Uint16 debug_data);
+#endif
+

--- a/main.c
+++ b/main.c
@@ -5,6 +5,7 @@
 #include "iic.h"
 #include "adc.h"
 #include "sci.h"
+#include "EPWM.h"
 
 // 定义要控制的变量
 volatile Uint16 controlValue = 0;
@@ -36,8 +37,6 @@ void delay_loop()
 }
 
 
-
-
 int main(void)
 {
     // Step 1. 系统初始化
@@ -55,7 +54,7 @@ int main(void)
     OLED_Init();//OLED初始化
 
     USARTA_Init(38400);
-    Prints("hello wrold!");
+    USART1_SendString("hello wrold!");
     Prints("USART Test Begin:\r\n");
     Prints("Send DSP Some data,It Will Send Them Bcak!\r\n");
     TIM0_Init(60, Time0);
@@ -66,7 +65,7 @@ int main(void)
     // 全局中断使能
     EINT;
     ERTM;
-    
+
     OLED_Clear();
     OLED_ShowString(1,0,"This is an OLED",8);//
     OLED_ShowString(1,1,"example using",8);//
@@ -75,15 +74,15 @@ int main(void)
     {
         int32 voltage_int = (int32)(Vin * 1000);
 
-
  //       PrintLongInt(voltage_int);
        // Vin=3.3/4095.0*910.0/51.0*Voltage1[2];
-        Vin=3.3/4095.0*Voltage1[2]*10.0;
+        Vin=3.3/4095.0* SADC.V1*10.0;
         EPwm1A_SetCompare(1500);
         EPwm2A_SetCompare(1500);
         degC = GetTemperatureC(Voltage2[2]);
         degK = GetTemperatureK(Voltage2[2]);
-        OLED_ShowNum(0,3,Voltage1[2],5,16);
+        OLED_ShowNum(0,3,SADC.V1,5,16);
+        //OLED_ShowNum(0,3,Voltage1[2],5,16);
         OLED_ShowNum(40,3,Vin,3,16);
         OLED_ShowNum(0,5,degC,3,16);
         OLED_ShowNum(40,5,degK,3,16);
@@ -92,19 +91,19 @@ int main(void)
 //         delay_loop();
 //         LED1_OFF;
         //接收到的数据原路发送回去
-//        // 检查是否有接收到数据
-//        if (usart1_rx_length > 0)
-//        {
-//            Uint16 i;
-//            // 发送接收到的数据
-//            for (i = 0; i < usart1_rx_length; i++)
-//            {
-//                USART_Transmit(COM1_RxBuff[i]);
-//            }
-//
-//            // 重置接收数据长度计数器
-//            usart1_rx_length = 0;
-//        }
+        // 检查是否有接收到数据
+        if (usart1_rx_length > 0)
+        {
+            Uint16 i;
+            // 发送接收到的数据
+            for (i = 0; i < usart1_rx_length; i++)
+            {
+                USART_Transmit(COM1_RxBuff[i]);
+            }
+
+            // 重置接收数据长度计数器
+            usart1_rx_length = 0;
+        }
 
 
 

--- a/own_code/EPWM/EPWM.c
+++ b/own_code/EPWM/EPWM.c
@@ -1,0 +1,252 @@
+#include "EPWM.h"
+
+void EPWM1_Init(Uint16 tbprd)
+{
+    //使能ePWM外设
+    EALLOW;
+    SysCtrlRegs.PCLKCR0.bit.TBCLKSYNC = 0;          // 失能ePWM外设时钟
+    SysCtrlRegs.PCLKCR1.bit.EPWM1ENCLK = 1;      // 使能ePWM1
+    EDIS;
+
+    // Disable Sync
+    EPwm1Regs.TBCTL.bit.SYNCOSEL = 11;  // Pass through
+    // Initially disable Free/Soft Bits
+    EPwm1Regs.TBCTL.bit.FREE_SOFT = 0;
+
+    //开启ePWM1对应GPIO时钟及初始化配置
+    InitEPwm1Gpio();
+    //开启ePWM1对应TZ配置
+    InitTzGpio();
+
+//    ISR functions found within this file.
+//    EALLOW;
+//    PieVectTable.EPWM1_TZINT = &epwm1_tzint_isr;
+//    EDIS;
+
+//    EALLOW;
+//    SysCtrlRegs.PCLKCR0.bit.TBCLKSYNC = 0;      // Stop all the TB clocks
+//    EDIS;
+
+   //Enable TZ1 and TZ2 as one shot trip sources
+   EALLOW;
+   EPwm1Regs.TZSEL.bit.CBC1 = 1;
+   EPwm1Regs.TZSEL.bit.CBC2 = 1;
+
+   // What do we want the TZ1 and TZ2 to do?
+   EPwm1Regs.TZCTL.bit.TZA = TZ_FORCE_LO;
+   EPwm1Regs.TZCTL.bit.TZB = TZ_FORCE_LO;
+
+   // Enable TZ interrupt 当需要TZ中断服务函数时使用
+   //EPwm1Regs.TZEINT.bit.OST = 1;
+
+
+   EDIS;
+
+    //初始化时基模块
+    //时钟同步输入设置
+//    EPwm1Regs.TBCTL.bit.SYNCOSEL = TB_SYNC_DISABLE;   // 异步
+    // Allow each timer to be sync'ed
+//    EPwm1Regs.TBCTL.bit.PHSEN = TB_DISABLE;                   //不使用相位
+//    EPwm1Regs.TBPHS.half.TBPHS = 0;                           //相位值
+    EPwm1Regs.TBCTR = 0x0000;                                   //清除计数器
+    EPwm1Regs.TBPRD = tbprd;                                    //设置周期
+    EPwm1Regs.TBCTL.bit.CTRMODE = TB_COUNT_UP;                  //向上计数
+    EPwm1Regs.TBCTL.bit.HSPCLKDIV=TB_DIV1;                      //设置分频
+    EPwm1Regs.TBCTL.bit.CLKDIV=TB_DIV1;
+
+    //初始化比较模块
+    // Setup shadow register load on ZERO [CC]
+    EPwm1Regs.CMPCTL.bit.SHDWAMODE = CC_SHADOW;//SA 影子寄存器
+    EPwm1Regs.CMPCTL.bit.SHDWBMODE = CC_SHADOW;//SB 影子寄存器
+    EPwm1Regs.CMPCTL.bit.LOADAMODE = CC_CTR_ZERO;//CTL=0时加载
+    EPwm1Regs.CMPCTL.bit.LOADBMODE = CC_CTR_ZERO;//CTL=0时加载
+
+    EPwm1Regs.ETSEL.bit.SOCAEN = 1; // 使能A组SOC
+    EPwm1Regs.ETSEL.bit.SOCASEL = 4; // 选择从CPMA上计数选择SOC
+    EPwm1Regs.ETPS.bit.SOCAPRD = 1; // 在第一个事件上生成脉冲
+
+    // 设置比较值
+    EPwm1Regs.CMPA.half.CMPA =0;    // Set compare A value
+//    EPwm1Regs.CMPB = 0;                     // Set Compare B value
+
+    //初始动作限定模块[AQ]
+    EPwm1Regs.AQCTLA.bit.PRD = AQ_SET;            // Set PWM1A on Zero
+    EPwm1Regs.AQCTLA.bit.CAU = AQ_CLEAR;       // Clear PWM1A on event A, up count
+
+//    EPwm1Regs.AQCTLB.bit.ZRO = AQ_CLEAR;       // Set PWM1B on Zero
+//    EPwm1Regs.AQCTLB.bit.CAU = AQ_SET;            // Clear PWM1B on event B, up count
+    //初始化事件触发模块[ET]
+    EPwm1Regs.ETSEL.bit.INTSEL = ET_CTR_ZERO;  // Select INT on Zero event
+    EPwm1Regs.ETSEL.bit.INTEN = 1;                      // Enable INT
+    EPwm1Regs.ETPS.bit.INTPRD = ET_1ST;            // 发生1次事件，产生1个中断
+
+    EALLOW;
+    PieVectTable.EPWM1_INT = &epwm1_timer_isr;
+    EDIS;
+    //死区设置、斩波设置
+    EPwm1Regs.DBCTL.bit.OUT_MODE = DB_FULL_ENABLE;
+    // 上升沿延迟器输出端口不翻转，下升沿延迟器输出端口翻转；
+    EPwm1Regs.DBCTL.bit.POLSEL = DB_ACTV_HIC;
+    //死区8*1/60MHz
+    EPwm1Regs.DBFED = 8;
+    //死区8*1/60MHz
+    EPwm1Regs.DBRED = 8;
+
+    //使能时基计数时钟
+    EALLOW;
+    SysCtrlRegs.PCLKCR0.bit.TBCLKSYNC = 1;         // Start all the timers synced
+    EDIS;
+
+    // Enable CPU INT3 which is connected to EPWM1-3 INT:
+    IER |= M_INT3;
+    // Enable EPWM INTn in the PIE: Group 3 interrupt 1-6
+    PieCtrlRegs.PIEIER3.bit.INTx1 = PWM1_INT_ENABLE;
+
+    // Enable EPWM INTn in the PIE: Group 3 interrupt 1-3
+//    PieCtrlRegs.PIEIER2.bit.INTx1 = 1;
+
+    EINT;
+    ERTM;
+}
+
+void EPWM2_Init(Uint16 tbprd)
+{
+    // 使能 ePWM 外设
+    EALLOW;
+    SysCtrlRegs.PCLKCR0.bit.TBCLKSYNC = 0;          // 失能 ePWM 外设时钟
+    SysCtrlRegs.PCLKCR1.bit.EPWM2ENCLK = 1;         // 使能 ePWM2
+    EDIS;
+
+    // 禁用同比信号
+    EPwm2Regs.TBCTL.bit.SYNCOSEL = 11;  // 选择同步信号为直通模式
+    // 初始禁用自动运行/软启动位
+    EPwm2Regs.TBCTL.bit.FREE_SOFT = 0;
+
+    // 开启 ePWM2 对应 GPIO 时钟及初始化配置
+    InitEPwm2Gpio();
+    // 开启 ePWM2 对应 TZ 配置
+    InitTzGpio();
+
+    // 启用TZ1和TZ2作为单次触发源
+    EALLOW;
+    EPwm2Regs.TZSEL.bit.CBC1 = 1;
+    EPwm2Regs.TZSEL.bit.CBC2 = 1;
+
+    // 设置TZ1和TZ2的动作
+    EPwm2Regs.TZCTL.bit.TZA = TZ_FORCE_LO;
+    EPwm2Regs.TZCTL.bit.TZB = TZ_FORCE_LO;
+
+    // Enable TZ interrupt 当需要 TZ 中断服务函数时使用
+    // EPwm2Regs.TZEINT.bit.OST = 1;
+
+    EDIS;
+
+    // 初始化时基模块
+    EPwm2Regs.TBCTR = 0x0000;                                   // 清除计数器
+    EPwm2Regs.TBPRD = tbprd;                                    // 设置周期
+    EPwm2Regs.TBCTL.bit.CTRMODE = TB_COUNT_UP;                  // 向上计数
+    EPwm2Regs.TBCTL.bit.HSPCLKDIV = TB_DIV1;                    // 设置分频
+    EPwm2Regs.TBCTL.bit.CLKDIV = TB_DIV1;
+
+    // 初始化比较模块
+    // 设置影子寄存器加载模式为当计数器为0时候加载
+    EPwm2Regs.CMPCTL.bit.SHDWAMODE = CC_SHADOW; // SA 影子寄存器
+    EPwm2Regs.CMPCTL.bit.SHDWBMODE = CC_SHADOW; // SB 影子寄存器
+    EPwm2Regs.CMPCTL.bit.LOADAMODE = CC_CTR_ZERO; // CTL=0 时加载
+    EPwm2Regs.CMPCTL.bit.LOADBMODE = CC_CTR_ZERO; // CTL=0 时加载
+
+    // 设置比较值
+    EPwm2Regs.CMPA.half.CMPA = 0;    // 设置比较值A为0
+    // EPwm2Regs.CMPB = 0;                     // Set Compare B value
+
+    // 初始动作限定模块 [AQ]
+    EPwm2Regs.AQCTLA.bit.PRD = AQ_SET;            // 在计数器达到周期时候置高
+    EPwm2Regs.AQCTLA.bit.CAU = AQ_CLEAR;          // 在计数器向上计数到CMPA时候置低
+
+    // EPwm2Regs.AQCTLB.bit.ZRO = AQ_CLEAR;       // 在计数器为0时候置0
+    // EPwm2Regs.AQCTLB.bit.CAU = AQ_SET;         // 在计数器到达CMPB时候置高
+
+    // 初始化事件触发模块 [ET]
+    EPwm2Regs.ETSEL.bit.INTSEL = ET_CTR_ZERO;     // 选择中断在计数器为0时候触发
+    EPwm2Regs.ETSEL.bit.INTEN = 1;                //
+    EPwm2Regs.ETPS.bit.INTPRD = ET_1ST;           // 发生 1 次事件，产生 1 个中断
+
+    EALLOW;
+    PieVectTable.EPWM2_INT = &epwm2_timer_isr;
+    EDIS;
+
+    // 死区设置、斩波设置
+    EPwm2Regs.DBCTL.bit.OUT_MODE = DB_FULL_ENABLE;
+    // 上升沿延迟器输出端口不翻转，下升沿延迟器输出端口翻转；
+    EPwm2Regs.DBCTL.bit.POLSEL = DB_ACTV_HIC;
+    // 死区 8 * 1/60MHz
+    EPwm2Regs.DBFED = 8;
+    // 死区 8 * 1/60MHz
+    EPwm2Regs.DBRED = 8;
+
+    // 使能时基计数时钟
+    EALLOW;
+    SysCtrlRegs.PCLKCR0.bit.TBCLKSYNC = 1;         // Start all the timers synced
+    EDIS;
+
+    // Enable CPU INT3 which is connected to EPWM1-3 INT:
+    IER |= M_INT3;
+    // Enable EPWM INTn in the PIE: Group 3 interrupt 1-6
+    PieCtrlRegs.PIEIER3.bit.INTx2 = PWM2_INT_ENABLE;
+
+    EINT;
+    ERTM;
+}
+
+
+void EPwm1A_SetCompare(Uint16 val)    //设置EPWM1A占空比
+{
+    EPwm1Regs.CMPA.half.CMPA = val;  //设置占空比
+}
+
+
+void EPwm1B_SetCompare(Uint16 val)  //设置EPWM1B占空比
+{
+    EPwm1Regs.CMPB = val;  //设置占空比
+}
+
+void EPwm2A_SetCompare(Uint16 val)    //设置EPWM2A占空比
+{
+    EPwm2Regs.CMPA.half.CMPA = val;  //设置占空比
+}
+
+
+void EPwm2B_SetCompare(Uint16 val)  //设置EPWM2B占空比
+{
+    EPwm2Regs.CMPB = val;  //设置占空比
+}
+
+interrupt void epwm1_timer_isr(void)
+{
+    static Uint16 cnt=0;
+    cnt++;
+    if(cnt==20000)
+    {
+        cnt=0;
+    }
+
+    // 清除此定时器的中断标志
+    EPwm1Regs.ETCLR.bit.INT = 1;
+    // 确认此中断，以便从组3接收更多中断
+    PieCtrlRegs.PIEACK.bit.ACK3 = 1;
+}
+
+interrupt void epwm2_timer_isr(void)
+{
+    static Uint16 cnt2=0;
+    cnt2++;
+    if(cnt2==20000)
+    {
+        cnt2=0;
+    }
+
+    // 清除此定时器的中断标志
+    EPwm2Regs.ETCLR.bit.INT = 1;
+    // 确认此中断，
+    PieCtrlRegs.PIEACK.bit.ACK3 = 1;
+}

--- a/own_code/EPWM/EPWM.h
+++ b/own_code/EPWM/EPWM.h
@@ -1,0 +1,26 @@
+#ifndef EPWM_H_
+#define EPWM_H_
+
+#include "DSP2803x_Device.h"     // DSP2833x 头文件
+#include "DSP2803x_Examples.h"   // DSP2833x 例子相关头文件
+
+
+
+interrupt void epwm1_timer_isr(void);
+interrupt void epwm2_timer_isr(void);
+void EPWM1_Init(Uint16 tbprd);
+void EPwm1A_SetCompare(Uint16 val);
+void EPwm1B_SetCompare(Uint16 val);
+void EPWM2_Init(Uint16 tbprd);
+void EPwm2A_SetCompare(Uint16 val);
+void EPwm2B_SetCompare(Uint16 val);
+
+
+
+
+
+
+
+
+#endif
+

--- a/own_code/SCI/sci.c
+++ b/own_code/SCI/sci.c
@@ -30,7 +30,6 @@ Uint16  Gu16_modbus_bits_outputIO[USART1_RX_LENGTH_MAX];
 unsigned int    time_usart1,time_usart2;
 
 
-
 /**
  * @brief USARTA接收中断处理函数
  */

--- a/own_code/adc/adc.h
+++ b/own_code/adc/adc.h
@@ -1,6 +1,5 @@
 /*
  * adc.h
- *
  *  Created on: 2018-1-29
  *      Author: Administrator
  */
@@ -11,7 +10,7 @@
 #include "DSP2803x_Device.h"     // DSP2833x 头文件
 #include "DSP2803x_Examples.h"   // DSP2833x 例子相关头文件
 
-
+extern  struct  Get_Value SADC;
 
 #define ADC_MODCLK 3
 
@@ -30,10 +29,30 @@ extern Uint16 SampleTable[BUF_SIZE];
 #define KELVIN_OFF FP_SCALE*KELVIN
 
 
+
+//定义结构体 ADC数值的各种参数
+struct Get_Value
+{
+    long V0;
+
+    long V1;
+    long I1;
+
+    long Iin;
+    long Vin;
+
+    long Iout;
+    long Vout;
+};
+
+
 void ADC_Init(void);
 Uint16 Read_ADC_CH0_Value(void);
 void Read_ADC_SEQ1_Value_OVD(void);
 interrupt void  adc_isr(void);
+
+void ADCSample(void);
+void PwmReflash(void);
 
 //内部温度采集函数
 int16 GetTemperatureC(int16 sensorSample);

--- a/own_code/time/tim.c
+++ b/own_code/time/tim.c
@@ -8,9 +8,6 @@
 #include "DSP2803x_Examples.h"   // DSP2833x 例子相关头文件
 
 
-//#include "leds.h"
-
-
 //定时器0初始化函数
 //Freq：CPU时钟频率（MHz）
 //Period：定时周期值，单位us
@@ -49,8 +46,8 @@ void TIM0_Init(float Freq, float Period)
     //使能总中断
     EINT;
     ERTM;
-
 }
+
 
 interrupt void TIM0_IRQn(void)
 {


### PR DESCRIPTION
此版本为保护性版本，在后面的版本，将EPWM模块更改为移相模式，特此保存。
（此版本加入结构体型电压、电流，并通过ADC获取，将EPWM模块单独移出作为独立模块使用）